### PR TITLE
Collection urls for nested resources

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -608,8 +608,10 @@
 				this.related.unbind( 'add', this.handleAddition ).unbind('remove', this.handleRemoval );
 				this.related = attr;
 				this.related.bind( 'add', this.handleAddition ).bind( 'remove', this.handleRemoval );
-			}
-			else {
+			} else if( this.related instanceof Backbone.Collection ) {
+				this.setRelated( this.related );
+				this.findRelated();
+			} else {
 				this.setRelated( this.getNewCollection() );
 				this.findRelated();
 			}


### PR DESCRIPTION
Reuse this.related if it is already a Backbone.Collection.  This allows a url to be set on the initial Collection and prevents it from getting wiped clean when new data is retrieved.

```
        relations: [{
            type: Backbone.HasMany,
            key: 'pages',
            relatedModel: 'app.models.Page',
            reverseRelation: {
                key: 'project',
            }
        }],

        initialize: function(){
            this.get('pages').url = _.bind(function(){
                return this.url() + "/pages"
            }, this);
        },
```
