### PR TITLE
Bug fix for circular relational reference in toJSON.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1033,6 +1033,7 @@
 			if ( this.isLocked() ) {
 				return this.id;
 			}
+			this.acquire();
 			
 			var json = Backbone.Model.prototype.toJSON.call( this );
 			
@@ -1057,6 +1058,7 @@
 					}
 				}, this );
 			
+			this.release();
 			return json;
 		}
 	});


### PR DESCRIPTION
Hi Paul, 

When I set up a model tree, there was a circular reference which I broke using: acquire() and release(). This was the relationship:

class SomeModel extends Backbone.RelationalModel
  relations: [{
      type: Backbone.HasMany
      key: 'children'
      relatedModel: SomeModel
      includeInJSON: 'id'
      reverseRelation: {
        type: Backbone.HasOne
        key: 'parent'
        includeInJSON: 'id'
      }
    }]

Also, I tried yesterday (you can see the closed pull request from yesterday) to handle saving the dependency between the models. Yesterday, I tried saving the cid, but with a bit of thought (and I wasn't happy with the massive changes), I decided to simplify things and save first the child (so I could get a new id assigned) and then in the success callback, to save the parent.

```
  new_model = new SomeModel({name: new_name})
  parent_model.get('children').add(new_model)
  new_model.save(null, {
    success: ->
      parent_model.save(null)
  })
```

There is some risk to have a dangling reference if the child save fails, but I guess that is fine since the parent can clean up the relationship or choose not to save....unless you believe there should be a dependent save introduced in Backbone.relational ;-P
