### PR TITLE
Attempting to add an invalid model (HasMany relationship) to a collection

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -705,6 +705,9 @@
 		 */
 		handleAddition: function( model, coll, options ) {
 			//console.debug('handleAddition called; args=%o', arguments);
+			// Make sure the model is in fact a valid model before continuing
+			if( !(model instanceof Backbone.Model) ) return;
+			
 			options = this.sanitizeOptions( options );
 			var dit = this;
 			


### PR DESCRIPTION
Hi Paul,

I just ran into this small issue when trying to add "invalid" models to a collection, so I added the one line of code to fix it, which is at the top of `HasMany.handleAddition`.

The issue is this: If I try to add a newly created object (not a model at this point) to a collection, Backbone runs `_prepareModel()`, which creates the model and also tries to validate it at the same time. 

If the attributes don't validate, `_prepareModel()` returns false, which is eventually passed down to the `Relation.getReverseRelations` function, at which time it's trying to call `model.getRelations()` on the expected model and errors out.

To get around this, I'm simply checking to make sure the model parameter passed to `HasMany.handleAddition` is in fact a Backbone model, otherwise just returning so the rest of the actions don't run.
