### PR TITLE
Use an internal Backbone.console for warning messages

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -23,6 +23,15 @@
 	
 	Backbone.Relational = {};
 	
+	Backbone.NullConsole = function(){
+	  var names = [ 'log', 'debug', 'info', 'warn', 'error', 'assert', 'dir', 'dirxml',
+  	'group', 'groupEnd', 'time', 'timeEnd', 'count', 'trace', 'profile', 'profileEnd' ];
+  	for ( var i = 0; i < names.length; ++i )
+  		this[ names[i] ] = function() {};
+	};
+	
+	Backbone.console = console || new Backbone.NullConsole();
+	
 	/**
 	 * Semaphore mixin; can be used as both binary and counting.
 	 **/
@@ -344,22 +353,22 @@
 		checkPreconditions: function() {
 			var i = this.instance, k = this.key, rm = this.relatedModel;
 			if ( !i || !k || !rm ) {
-				console && console.warn( 'Relation=%o; no instance, key or relatedModel (%o, %o, %o)', this, i, k, rm );
+				Backbone.console.warn( 'Relation=%o; no instance, key or relatedModel (%o, %o, %o)', this, i, k, rm );
 				return false;
 			}
 			// Check if 'instance' is a Backbone.RelationalModel
 			if ( !( i instanceof Backbone.RelationalModel ) ) {
-				console && console.warn( 'Relation=%o; instance=%o is not a Backbone.RelationalModel', this, i );
+				Backbone.console.warn( 'Relation=%o; instance=%o is not a Backbone.RelationalModel', this, i );
 				return false;
 			}
 			// Check if the type in 'relatedModel' inherits from Backbone.RelationalModel
 			if ( !( rm.prototype instanceof Backbone.RelationalModel.prototype.constructor ) ) {
-				console && console.warn( 'Relation=%o; relatedModel does not inherit from Backbone.RelationalModel (%o)', this, rm );
+				Backbone.console.warn( 'Relation=%o; relatedModel does not inherit from Backbone.RelationalModel (%o)', this, rm );
 				return false;
 			}
 			// Check if this is not a HasMany, and the reverse relation is HasMany as well
 			if ( this instanceof Backbone.HasMany && this.reverseRelation.type === Backbone.HasMany.prototype.constructor ) {
-				console && console.warn( 'Relation=%o; relation is a HasMany, and the reverseRelation is HasMany as well.', this );
+				Backbone.console.warn( 'Relation=%o; relation is a HasMany, and the reverseRelation is HasMany as well.', this );
 				return false;
 			}
 			// Check if we're not attempting to create a duplicate relationship
@@ -371,7 +380,7 @@
 				}, this );
 				
 				if ( exists ) {
-					console && console.warn( 'Relation=%o between instance=%o.%s and relatedModel=%o.%s already exists',
+					Backbone.console.warn( 'Relation=%o between instance=%o.%s and relatedModel=%o.%s already exists',
 						this, i, k, rm, this.reverseRelation.key );
 					return false;
 				}
@@ -839,7 +848,7 @@
 						new type( this, rel ); // Also pushes the new Relation into _relations
 					}
 					else {
-						console && console.warn( 'Relation=%o; missing or invalid type!', rel );
+						Backbone.console.warn( 'Relation=%o; missing or invalid type!', rel );
 					}
 				}, this );
 			

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,14 +4,6 @@
 // jQueryUI examples: https://github.com/jquery/jquery-ui/tree/master/tests/unit
 
 //sessionStorage.clear();
-if ( !window.console ) {
-	var names = [ 'log', 'debug', 'info', 'warn', 'error', 'assert', 'dir', 'dirxml',
-	'group', 'groupEnd', 'time', 'timeEnd', 'count', 'trace', 'profile', 'profileEnd' ];
-	window.console = {};
-	for ( var i = 0; i < names.length; ++i )
-		window.console[ names[i] ] = function() {};
-}
-
 $(document).ready(function() {
 	$.ajax = function( obj ) {
 		window.requests.push( obj );


### PR DESCRIPTION
This allow to deactivate warning messages for backbone-relational, without having to modify the global console object. For doing so, a new Backbone.NullConsole object is created. I moved the code that created an empty console in the tests to this object. Now you can disable backbone-relational warning traces just doing: `Backbone.console = new Backbone.NullConsole();`
