### PR TITLE
pass current model as parent

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -401,7 +401,7 @@
 		
 		createModel: function( item ) {
 			if ( this.options.createModels && typeof( item ) === 'object' ) {
-				return new this.relatedModel( item );
+				return new this.relatedModel( item, this.instance );
 			}
 		},
 		


### PR DESCRIPTION
This simple modification will pass the current model to the newly created model, giving the new (child) model the option of calling the parent.
