### PR TITLE
I had some trouble with related instances that did already exist before ...

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1177,7 +1177,7 @@
 				// Try to find 'model' in Backbone.store. If it already exists, set the new properties on it.
 				var existingModel = Backbone.Relational.store.find( this.model, model[ this.model.prototype.idAttribute ] );
 				if ( existingModel ) {
-					existingModel.set( model, options );
+					existingModel.set( options.parse ? existingModel.parse(model) : model, options );
 					model = existingModel;
 				}
 				else {


### PR DESCRIPTION
...calling fetch on the collection. For new instances, the data will be piped through the parse method of the model class, for already existing instances, this is bypassed.

My quick workaround is this change, but I am not sure if this is the right way to fix it. Maybe it is better to enhance the set method of RelationalModel to understand options.parse?
