### PR TITLE
Serialize `null` relations as `null` in #toJSON().

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -710,7 +710,7 @@
 		},
 		
 		_getCollectionOptions: function() {
-		    return _.isFunction( this.options.collectionOptions ) ?
+			return _.isFunction( this.options.collectionOptions ) ?
 				this.options.collectionOptions( this.instance ) :
 				this.options.collectionOptions;
 		},
@@ -1248,8 +1248,13 @@
 			_.each( this._relations, function( rel ) {
 				var value = json[ rel.key ];
 
-				if ( rel.options.includeInJSON === true && value && _.isFunction( value.toJSON ) ) {
-					json[ rel.keyDestination ] = value.toJSON();
+				if ( rel.options.includeInJSON === true) {
+					if ( value && _.isFunction( value.toJSON ) ) {
+						json[ rel.keyDestination ] = value.toJSON();
+					}
+					else {
+						json[ rel.keyDestination ] = null;
+					}
 				}
 				else if ( _.isString( rel.options.includeInJSON ) ) {
 					if ( value instanceof Backbone.Collection ) {
@@ -1257,6 +1262,9 @@
 					}
 					else if ( value instanceof Backbone.Model ) {
 						json[ rel.keyDestination ] = value.get( rel.options.includeInJSON );
+					}
+					else {
+						json[ rel.keyDestination ] = null;
 					}
 				}
 				else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -80,8 +80,8 @@ $(document).ready(function() {
 		model: Animal,
 		
 		initialize: function( models, options ) {
-		    options || (options = {});
-	        this.url = options.url;
+			options || (options = {});
+			this.url = options.url;
 		}
 	});
 
@@ -123,6 +123,7 @@ $(document).ready(function() {
 			{
 				type: Backbone.HasOne,
 				key: 'user',
+				keyDestination: 'user_id',
 				relatedModel: 'User',
 				includeInJSON: Backbone.Model.prototype.idAttribute,
 				reverseRelation: {
@@ -611,7 +612,7 @@ $(document).ready(function() {
 		
 		test( "'includeInJSON' (Person to JSON)", function() {
 			var json = person1.toJSON();
-			equal( json.user, 'user-1', "The value 'user' is the user's id (not an object, since 'includeInJSON' is set to the idAttribute)" );
+			equal( json.user_id, 'user-1', "The value of 'user_id' is the user's id (not an object, since 'includeInJSON' is set to the idAttribute)" );
 			ok ( json.likesALot instanceof Object, "The value of 'likesALot' is an object ('includeInJSON' is 'true')" );
 			equal(  json.likesALot.likesALot, 'person-1', "Person is serialized only once" );
 			
@@ -621,6 +622,10 @@ $(document).ready(function() {
 			json = person2.toJSON();
 			ok( person2.get('livesIn') instanceof House, "'person2' has a 'livesIn' relation" );
 			equal( json.livesIn, undefined , "The value of 'livesIn' is not serialized ('includeInJSON is 'false')" );
+			
+			json = person3.toJSON();
+			ok( json.user_id === null, "The value of 'user_id' is null");
+			ok( json.likesALot === null, "The value of 'likesALot' is null");
 		});
 		
 		test( "'createModels' is false", function() {
@@ -734,9 +739,9 @@ $(document).ready(function() {
 			ok( typeof viewJSON.properties === 'undefined', "'viewJSON' does not have 'properties'" );
 		});
 		
-		test( "'collectionOptionsCallback' sets the options on the created HasMany Collections", function() {
-		    var zoo = new Zoo();
-		    ok( zoo.get("animals").url === "zoo/" + zoo.cid + "/animal/");
+		test( "'collectionOptions' sets the options on the created HasMany Collections", function() {
+			var zoo = new Zoo();
+			ok( zoo.get("animals").url === "zoo/" + zoo.cid + "/animal/");
 		});
 		
 		


### PR DESCRIPTION
Relations with a value of `null` used to not be included in the object returned by `#toJSON()` at all, but are now properly represented as `null`. 

This is useful when you want to get rid of a relation between two objects by setting the relation to `null`, and you want this value to actually be saved to the server.
