### PR TITLE
Fixes #104: Trigger appropriate `remove` events when a HasMany relation's key is changed.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -816,7 +816,7 @@
 
 				if ( this.related instanceof Backbone.Collection ) {
 					coll = this.related;
-					coll.reset( [], { silent: true } );
+					coll.remove( coll.models );
 				}
 				else {
 					coll = this._prepareCollection();


### PR DESCRIPTION
[Your solution](https://github.com/PaulUithol/Backbone-relational/issues/104#issuecomment-5089324) pointed out in #104 worked perfectly for me without any regressions, so here it is!
