### PR TITLE
Add option to guarantee fetchRelated hits server

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,11 @@ It's only mandatory to supply a `key`; `relatedModel` is automatically set. The 
 
 Returns the set of initialized relations on the model.
 
-###### **fetchRelated `relationalModel.fetchRelated(key<string>, [options<object>])`**
+###### **fetchRelated `relationalModel.fetchRelated(key<string>, [options<object>], [replace<boolean>])`**
 
 Fetch models from the server that were referenced in the model's attributes, but have not been found/created yet.
-This can be used specifically for lazy-loading scenarios.
+This can be used specifically for lazy-loading scenarios.  Setting `replace` to true guarantees that the model
+will be fetched from the server and any model in the store will be replaced with the new version.
 
 By default, a separate request will be fired for each additional model that is to be fetched from the server.
 However, if your server/API supports it, you can fetch the set of models in one request by specifying a `collectionType`

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1128,9 +1128,10 @@
 		 * Retrieve related objects.
 		 * @param key {string} The relation key to fetch models for.
 		 * @param options {Object} Options for 'Backbone.Model.fetch' and 'Backbone.sync'.
+		 * @param replace {boolean} Whether to fetch from the server, replacing the store if present
 		 * @return {jQuery.when[]} An array of request objects
 		 */
-		fetchRelated: function( key, options ) {
+		fetchRelated: function( key, options, replace ) {
 			options || ( options = {} );
 			var setUrl,
 				requests = [],
@@ -1138,7 +1139,7 @@
 				keyContents = rel && rel.keyContents,
 				toFetch = keyContents && _.select( _.isArray( keyContents ) ? keyContents : [ keyContents ], function( item ) {
 					var id = Backbone.Relational.store.resolveIdForItem( rel.relatedModel, item );
-					return id && !Backbone.Relational.store.find( rel.relatedModel, id );
+					return id && (replace || !Backbone.Relational.store.find( rel.relatedModel, id ));
 				}, this );
 			
 			if ( toFetch && toFetch.length ) {


### PR DESCRIPTION
Add an optional third parameter to fetchRelated, `replace`, which
when true guarantees that `fetchRelated` will actually get the latest
resources from the server and update the Backbone.Relational.store
accordingly.

This is extremely useful for keeping related resources up-to-date without needing to construct a more complicated Backbone.Model.fetch call.
