### PR TITLE
Added support for self-referential relationships between models when using AMD / RequireJS

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -375,7 +375,14 @@
 		// 'exports' should be the global object where 'relatedModel' can be found on if given as a string.
 		this.relatedModel = this.options.relatedModel;
 		if ( _.isString( this.relatedModel ) ) {
-			this.relatedModel = Backbone.Relational.store.getObjectByName( this.relatedModel );
+			if (this.relatedModel == "self")
+			{
+				this.relatedModel = this.model;
+			}
+			else
+			{
+				this.relatedModel = Backbone.Relational.store.getObjectByName( this.relatedModel );
+			}
 		}
 
 		if ( !this.checkPreconditions() ) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -193,6 +193,18 @@ $(document).ready(function() {
 		model: Node
 	});
 	
+
+	window.Category = Backbone.RelationalModel.extend({
+		relations: [{
+			type: Backbone.HasOne,
+			key: 'subcategory',
+			relatedModel: 'self',
+			reverseRelation: {
+				key: 'parent'
+			}
+		}]
+	});
+
 	function initObjects() {
 		// Reset last ajax requests
 		window.requests = [];
@@ -252,6 +264,17 @@ $(document).ready(function() {
 			location: 'outside of town',
 			occupants: [],
 			resource_uri: 'house-2'
+		});
+
+		window.subcategory = new Category({
+			id: 'subcatA',
+			name: 'Subcategory A'
+		});
+
+		window.categoryWithSubcategory = new Category({
+			id: 'mainCategory',
+			name: 'misc',
+			subcategory: 'subcatA'
 		});
 	}
 	
@@ -339,7 +362,7 @@ $(document).ready(function() {
 	
 	
 		test( "Initialized", function() {
-			equal( Backbone.Relational.store._collections.length, 5, "Store contains 5 collections" );
+			equal( Backbone.Relational.store._collections.length, 6, "Store contains 6 collections" );
 		});
 		
 		test( "getObjectByName", function() {
@@ -2038,5 +2061,9 @@ $(document).ready(function() {
 
 			equal( zoo.get( 'name' ), 'Zoo Station' );
 			equal( lion.get( 'name' ), 'Simba' );
+		});
+
+		test( "Self referential relatedModels", function() {
+			ok( categoryWithSubcategory.get("subcategory") instanceof Category );
 		});
 });


### PR DESCRIPTION
If special keyword string "self" is used in relatedModel, use the current model as the relatedModel.

Added test to show this works.
