### PR TITLE
fixed bug where indexes were all the same when adding models to collection

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1608,17 +1608,12 @@
 			var dit = this, args = arguments;
 			
 			if (eventName === 'add') {
-				var toBeCloned = args;
-				args = [];
-				_.each(toBeCloned, function(arg, index) {
-					if (index === 3) {
-						// these are the options containing the index a model element was added at.
-						var clonedArg = _.clone(arg);
-						args.push(clonedArg);
-					} else {
-						args.push(arg);
-					}
-				});
+				args = _.toArray(args);
+				// the fourth argument in case of a regular add is the option object.
+				// we need to clone it, as it could be modified while we wait on the eventQueue to be unblocked
+				if (_.isObject(args[3])) {
+					args[3] = _.clone(args[3]);
+				}
 			}
 			
 			Backbone.Relational.eventQueue.add( function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1571,7 +1571,43 @@ $(document).ready(function() {
 			Backbone.Collection.prototype.sort = sort;
 			delete AnimalCollection.prototype.comparator;
 		});
+
+		test( "Raw-models set to a hasMany relation do trigger an add event in the underlying Collection with a correct index", function() {
+			var zoo = new Zoo();
+
+			var indexes = [];
+
+			zoo.get("animals").on("add", function(collection, model, options) {
+				indexes.push(options.index);
+			});
+
+			zoo.set("animals", [
+					{ id : 1, species : 'Lion' },
+					{ id : 2, species : 'Zebra'}
+			]);
+
+			equal( indexes[0], 0, "First item has index 0" );
+			equal( indexes[1], 1, "Second item has index 1" );
+		});
 		
+		test( "Models set to a hasMany relation do trigger an add event in the underlying Collection with a correct index", function() {
+			var zoo = new Zoo();
+
+			var indexes = [];
+
+			zoo.get("animals").on("add", function(collection, model, options) {
+				indexes.push(options.index);
+			});
+
+			zoo.set("animals", [
+					new Animal({ id : 1, species : 'Lion' }),
+					new Animal({ id : 2, species : 'Zebra'})
+			]);
+
+			equal( indexes[0], 0, "First item has index 0" );
+			equal( indexes[1], 1, "Second item has index 1" );
+		});
+
 		test( "The 'collectionKey' options is used to create references on generated Collections back to its RelationalModel", function() {
 			var zoo = new Zoo({
 				animals: [ 'lion-1', 'zebra-1' ]


### PR DESCRIPTION
- happens because 'add' events are added to the relational event queue,
  passing the arguments (including options) as reference.. the index, at
  which a model was added is then changed for every call to trigger('add')
  so that when the event queue is finally run, options.index does only
  reflect the last change to the index and not the index the model was
  originally added at...

I am aware that my solution does not look very clean. Maybe someone has a better suggestion to preserve the original argument-values for triggered events
