### PR TITLE
Remove unnecessary options object duplication

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -563,7 +563,7 @@
 		sanitizeOptions: function( options ) {
 			options = options ? _.clone( options ) : {};
 			if ( options.silent ) {
-				options = _.extend( {}, options, { silentChange: true } );
+				options.silentChange = true;
 				delete options.silent;
 			}
 			return options;
@@ -578,7 +578,7 @@
 		unsanitizeOptions: function( options ) {
 			options = options ? _.clone( options ) : {};
 			if ( options.silentChange ) {
-				options = _.extend( {}, options, { silent: true } );
+				options.silent = true;
 				delete options.silentChange;
 			}
 			return options;


### PR DESCRIPTION
I've removed leftover code that created a second copy of options in sanitizeOptions and unsanitizeOptions methods. Originally options wasn't cloned which is why extend was used. Since it's now always cloned the extend is no longer required.
