### PR TITLE
Make 'MyModel.setup()' return 'MyModel'

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1424,6 +1424,7 @@
 						}
 					}
 				}, this );
+      return this;
 		},
 
 		/**


### PR DESCRIPTION
When using RequireJS and CoffeeScript, you may see code like this:

``` coffeescript
define (require)->
  Backbone = require 'backbone'
  require 'backbone-relational'

  class MyModel extends Backbone.RelationalModel

    relations: [
      # etc...
    ]
```

RequireJS / AMD works by passing a callback to the "define" function that returns the module. The above code returns the "MyModel" constructor function because of CoffeeScript's "everything is an expression" philosophy.
Adding `MyModel.setup()` at the end, as specified in the documentation, breaks this functionality.
A simple `return this;` at the end of "MyModel.setup()" fixes this.
