### PR TITLE
Fixed unregistering of models in Backbone-relational's store

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -353,8 +353,10 @@
 		 */
 		unregister: function( model ) {
 			model.unbind( 'destroy', this.unregister );
+			var modelColl = model.collection;
 			var coll = this.getCollection( model );
 			coll && coll.remove( model );
+			model.collection = modelColl;
 		}
 	});
 	Backbone.Relational.store = new Backbone.Store();


### PR DESCRIPTION
Hey there,

currently, when a model object is unregistered from the store of Backbone-relational, it looses the reference to its collection - that is `model.colletion` becomes an undefined value.

In my application that causes some trouble, because my model is stored in an undo-stack after it is destroyed an will be restored, if the user hits the "Undo"-Button. However, for the undo-process there needs to be a reference the the collection the model was originally in.

Feel free to merge this change if you like.

Regards.
