### PR TITLE
Added full relations serialization in toJSON

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1347,6 +1347,7 @@
 		 * Convert relations to JSON, omits them when required
 		 */
 		toJSON: function(options) {
+			options = options || {};
 			// If this Model has already been fully serialized in this branch once, return to avoid loops
 			if ( this.isLocked() ) {
 				return this.id;
@@ -1362,7 +1363,7 @@
 			_.each( this._relations || [], function( rel ) {
 					var value = json[ rel.key ];
 
-					if ( rel.options.includeInJSON === true) {
+					if ( options.full || rel.options.includeInJSON === true) {
 						if ( value && _.isFunction( value.toJSON ) ) {
 							json[ rel.keyDestination ] = value.toJSON( options );
 						}

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1345,6 +1345,9 @@
 		
 		/**
 		 * Convert relations to JSON, omits them when required
+		 *
+		 * IMPORTANT NOTE: the use of option `full=true` is very bad for performance. Do not use this in a loops!!
+		 *
 		 */
 		toJSON: function(options) {
 			options = options || {};
@@ -1364,11 +1367,13 @@
 					var value = json[ rel.key ];
 
 					if ( options.full || rel.options.includeInJSON === true) {
+						var jsonKey = options.full ? rel.key : rel.keyDestination;
+
 						if ( value && _.isFunction( value.toJSON ) ) {
-							json[ rel.keyDestination ] = value.toJSON( options );
+							json[ jsonKey ] = value.toJSON(options);
 						}
 						else {
-							json[ rel.keyDestination ] = null;
+							json[ jsonKey ] = null;
 						}
 					}
 					else if ( _.isString( rel.options.includeInJSON ) ) {
@@ -1409,7 +1414,7 @@
 						delete json[ rel.key ];
 					}
 
-					if ( rel.keyDestination !== rel.key ) {
+					if ( rel.keyDestination !== rel.key && !options.full ) {
 						delete json[ rel.key ];
 					}
 				});

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1351,6 +1351,7 @@
 		//
 		recursiveAttributes: function(options) {
 			options = options || {};
+			var that = this;
 
 			if ( this.isLocked() ) {
 				return this.id;
@@ -1368,6 +1369,8 @@
 
 				if ( value && _.isFunction( value.recursiveAttributes ) ) {
 					json[ rel.key ] = value.recursiveAttributes( options );
+				} else if ( value instanceof Backbone.Collection ){
+					json[ rel.key ] = value.map(function(model){ return that.recursiveAttributes.call(model, options); });
 				} else {
 					json[ rel.key ] = null;
 				}

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1363,11 +1363,11 @@
 				json[ this.constructor._subModelTypeAttribute ] = this.constructor._subModelTypeValue;
 			}
 
-			_.each( this._relations, function( rel ) {
+			_.each( this._relations || [], function( rel ) {
 				var value = json[ rel.key ];
 
 				if ( value && _.isFunction( value.recursiveAttributes ) ) {
-					json[ rel.key ] = value.recursiveAttributes(options);
+					json[ rel.key ] = value.recursiveAttributes( options );
 				} else {
 					json[ rel.key ] = null;
 				}
@@ -1408,7 +1408,7 @@
 
 				if ( rel.options.includeInJSON === true) {
 					if ( value && _.isFunction( value.toJSON ) ) {
-						json[ rel.keyDestination ] = value.toJSON(options);
+						json[ rel.keyDestination ] = value.toJSON( options );
 					}
 					else {
 						json[ rel.keyDestination ] = null;

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1343,6 +1343,41 @@
 			return new this.constructor( attributes );
 		},
 		
+		//
+		//  Returns the data-structure of the relational model.
+		//  Calling toJSON with options full=true redirects the call
+		//  to this method.
+		//  Useful for template rendering
+		//
+		recursiveAttributes: function(options) {
+			options = options || {};
+
+			if ( this.isLocked() ) {
+				return this.id;
+			}
+
+			this.acquire();
+			var json = Backbone.Model.prototype.toJSON.call( this, options );
+
+			if ( this.constructor._superModel && !( this.constructor._subModelTypeAttribute in json ) ) {
+				json[ this.constructor._subModelTypeAttribute ] = this.constructor._subModelTypeValue;
+			}
+
+			_.each( this._relations, function( rel ) {
+				var value = json[ rel.key ];
+
+				if ( value && _.isFunction( value.recursiveAttributes ) ) {
+					json[ rel.key ] = value.recursiveAttributes(options);
+				} else {
+					json[ rel.key ] = null;
+				}
+			});
+
+			this.release();
+			return json;
+
+		},
+
 		/**
 		 * Convert relations to JSON, omits them when required
 		 *
@@ -1351,6 +1386,11 @@
 		 */
 		toJSON: function(options) {
 			options = options || {};
+
+			if ( options.full ) {
+				return this.recursiveAttributes(options);
+			}
+
 			// If this Model has already been fully serialized in this branch once, return to avoid loops
 			if ( this.isLocked() ) {
 				return this.id;
@@ -1364,60 +1404,58 @@
 			}
 			
 			_.each( this._relations || [], function( rel ) {
-					var value = json[ rel.key ];
+				var value = json[ rel.key ];
 
-					if ( options.full || rel.options.includeInJSON === true) {
-						var jsonKey = options.full ? rel.key : rel.keyDestination;
-
-						if ( value && _.isFunction( value.toJSON ) ) {
-							json[ jsonKey ] = value.toJSON(options);
-						}
-						else {
-							json[ jsonKey ] = null;
-						}
-					}
-					else if ( _.isString( rel.options.includeInJSON ) ) {
-						if ( value instanceof Backbone.Collection ) {
-							json[ rel.keyDestination ] = value.pluck( rel.options.includeInJSON );
-						}
-						else if ( value instanceof Backbone.Model ) {
-							json[ rel.keyDestination ] = value.get( rel.options.includeInJSON );
-						}	
-						else {
-							json[ rel.keyDestination ] = null;
-						}
-					}
-					else if ( _.isArray( rel.options.includeInJSON ) ) {
-						if ( value instanceof Backbone.Collection ) {
-							var valueSub = [];
-							value.each( function( model ) {
-								var curJson = {};
-								_.each( rel.options.includeInJSON, function( key ) {
-									curJson[ key ] = model.get( key );
-								});
-								valueSub.push( curJson );
-							});
-							json[ rel.keyDestination ] = valueSub;
-						}
-						else if ( value instanceof Backbone.Model ) {
-							var valueSub = {};
-							_.each( rel.options.includeInJSON, function( key ) {
-								valueSub[ key ] = value.get( key );
-							});
-							json[ rel.keyDestination ] = valueSub;
-						}
-						else {
-							json[ rel.keyDestination ] = null;
-						}
+				if ( rel.options.includeInJSON === true) {
+					if ( value && _.isFunction( value.toJSON ) ) {
+						json[ rel.keyDestination ] = value.toJSON(options);
 					}
 					else {
-						delete json[ rel.key ];
+						json[ rel.keyDestination ] = null;
 					}
+				}
+				else if ( _.isString( rel.options.includeInJSON ) ) {
+					if ( value instanceof Backbone.Collection ) {
+						json[ rel.keyDestination ] = value.pluck( rel.options.includeInJSON );
+					}
+					else if ( value instanceof Backbone.Model ) {
+						json[ rel.keyDestination ] = value.get( rel.options.includeInJSON );
+					}
+					else {
+						json[ rel.keyDestination ] = null;
+					}
+				}
+				else if ( _.isArray( rel.options.includeInJSON ) ) {
+					if ( value instanceof Backbone.Collection ) {
+						var valueSub = [];
+						value.each( function( model ) {
+							var curJson = {};
+							_.each( rel.options.includeInJSON, function( key ) {
+								curJson[ key ] = model.get( key );
+							});
+							valueSub.push( curJson );
+						});
+						json[ rel.keyDestination ] = valueSub;
+					}
+					else if ( value instanceof Backbone.Model ) {
+						var valueSub = {};
+						_.each( rel.options.includeInJSON, function( key ) {
+							valueSub[ key ] = value.get( key );
+						});
+						json[ rel.keyDestination ] = valueSub;
+					}
+					else {
+						json[ rel.keyDestination ] = null;
+					}
+				}
+				else {
+					delete json[ rel.key ];
+				}
 
-					if ( rel.keyDestination !== rel.key && !options.full ) {
-						delete json[ rel.key ];
-					}
-				});
+				if ( rel.keyDestination !== rel.key ) {
+					delete json[ rel.key ];
+				}
+			});
 			
 			this.release();
 			return json;

--- a/test/tests.js
+++ b/test/tests.js
@@ -803,6 +803,16 @@ $(document).ready(function() {
 
 		});
 
+		test( "toJSON relational", function() {
+			var person1JSON = person1.toJSON();
+			equal( person1JSON.user_id, person1.get('user').get('id'), "The serialized person has a key 'user_id' which value is 'user.id' following specified relational model");
+			ok(person1JSON.user === undefined, "The serialized person has no 'user' key following specified relational model");
+
+			var person1FullJSON = person1.toJSON({full:true});
+			equal(person1FullJSON.user.login, 'dude', "The full serialization of person has a dict with key 'user'");
+			ok(person1FullJSON.user_id === undefined, "The full serialization of person has no key 'user_id'");
+		});
+
 		test( "constructor.findOrCreate", function() {
 			var personColl = Backbone.Relational.store.getCollection( person1 ),
 				origPersonCollSize = personColl.length;
@@ -1030,6 +1040,10 @@ $(document).ready(function() {
 			var json = dog.toJSON();
 			
 			equal( json.type, 'dog', "The value of 'type' is the pet animal's type." );
+
+			var fullJSON = dog.toJSON( {full:true} );
+
+			equal( json.type, 'dog', "The value of 'type' is the pet animal's type.");
 
 			delete window.PetAnimal;
 			delete window.Dog;

--- a/test/tests.js
+++ b/test/tests.js
@@ -803,7 +803,7 @@ $(document).ready(function() {
 
 		});
 
-		test( "toJSON relational", function() {
+		test( "toJSON full:true", function() {
 			var person1JSON = person1.toJSON();
 			equal( person1JSON.user_id, person1.get('user').get('id'), "The serialized person has a key 'user_id' which value is 'user.id' following specified relational model");
 			ok(person1JSON.user === undefined, "The serialized person has no 'user' key following specified relational model");
@@ -811,6 +811,23 @@ $(document).ready(function() {
 			var person1FullJSON = person1.toJSON({full:true});
 			equal(person1FullJSON.user.login, 'dude', "The full serialization of person has a dict with key 'user'");
 			ok(person1FullJSON.user_id === undefined, "The full serialization of person has no key 'user_id'");
+		});
+
+		test( "toJSON full:true hasMany", function() {
+			var zoo = new Zoo({
+				name: 'Artis',
+				animals: [
+					new Animal( { id: 1, species: 'bear', name: 'Baloo' } ),
+					new Animal( { id: 2, species: 'tiger', name: 'Shere Khan' } )
+				]
+			});
+
+			var fullJSON = zoo.toJSON({full:true});
+
+			equal( fullJSON.animals.length, 2 );
+			var bear = fullJSON.animals[ 0 ];
+			equal( bear.species, 'bear', "animal's species has been included in the JSON" );
+			equal( bear.name, 'Baloo', "animal's name is included in the JSON with `full:true` option" );
 		});
 
 		test( "constructor.findOrCreate", function() {


### PR DESCRIPTION
Hello there,

There are some situations when we need to make `toJSON` work in
different ways:
- Communication with server where relations may be reduced to `resource_uri`
- Template rendering where we need more information that the one we send to the server

Adding `{full: true}` to toJSON allows to avoid `includeInJSON` params and make a full
serialization of a model and its relations.

Related: GH-161. 

Cheers,
Javi