### PR TITLE
Call parse before retrieving idAttribute

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1512,14 +1512,15 @@
 		 * @return {Backbone.RelationalModel}
 		 */
 		findOrCreate: function( attributes, options ) {
+			var parsedAttributes = (_.isObject( attributes ) && this.prototype.parse) ? this.prototype.parse( attributes ) : attributes;
 			// Try to find an instance of 'this' model type in the store
-			var model = Backbone.Relational.store.find( this, attributes );
+			var model = Backbone.Relational.store.find( this, parsedAttributes );
 
 			// If we found an instance, update it with the data in 'item'; if not, create an instance
 			// (unless 'options.create' is false).
 			if ( _.isObject( attributes ) ) {
 				if ( model ) {
-					model.set( model.parse ? model.parse( attributes ) : attributes, options );
+					model.set( parsedAttributes, options );
 				}
 				else if ( !options || ( options && options.create !== false ) ) {
 					model = this.build( attributes, options );
@@ -1585,7 +1586,6 @@
 				modelsToAdd.push( model );
 			}
 		}, this );
-
 
 		// Add 'models' in a single batch, so the original add will only be called once (and thus 'sort', etc).
 		if ( modelsToAdd.length ) {


### PR DESCRIPTION
I have an API that returns the object payload as follow:
{
  result : {
    id : 123
    field1 : ...
  }
}

I have a custom parse method on my models that essentially does 'return response.result'.

In the findOrCreate method, the idAttribute must be retrieved and
it uses item[ type.prototype.idAttribute ]. This is fine when the
API returns the id as a top level key but it brakes otherwise and
parse must be called first.

I have not had a chance to write a unit test yet. I am new to javascript and backbone and I wanted to get your feedback on the change before I invest more time implementing a test case. This fix solves my particular problem but it may have side effects I am not aware of. Without this fix, I would get 'Cannot instantiate more than one Backbone.RelationalModel with the same id per type! ' errors since findOrCreate would never be able to pull the model idAttribute.
