### PR TITLE
Allow models to be set via the key attribute even if keySource is defined.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -411,15 +411,20 @@
 		}
 
 		if ( instance ) {
-			this.keyContents = this.instance.get( this.keySource );
+		    var contentKey = this.keySource;
+		    if ( contentKey !== this.key && typeof this.instance.get( this.key ) === 'object' ) {
+		        contentKey = this.key;
+		    }
 
-			// Explicitly clear 'keySource', to prevent a leaky abstraction if 'keySource' differs from 'key'.
-			if ( this.key !== this.keySource ) {
-				this.instance.unset( this.keySource, { silent: true } );
-			}
+		    this.keyContents = this.instance.get( contentKey );
 
-			// Add this Relation to instance._relations
-			this.instance._relations.push( this );
+		    // Explicitly clear 'keySource', to prevent a leaky abstraction if 'keySource' differs from 'key'.
+		    if ( this.keySource !== this.key ) {
+		        this.instance.unset( this.keySource, { silent: true } );
+		    }
+
+		    // Add this Relation to instance._relations
+		    this.instance._relations.push( this );
 		}
 
 		// Add the reverse relation on 'relatedModel' to the store's reverseRelations

--- a/test/tests.js
+++ b/test/tests.js
@@ -1381,6 +1381,38 @@ $(document).ready(function() {
 			equal( companyA.get('employees').length, 2, 'with elements' );
 		});
 
+		test("If keySource is used don't remove a model that is present in the key attribute", function() {
+			var ForumPost = Backbone.RelationalModel.extend({
+				// Normally would set something here, not needed for test
+			});
+			var ForumPostCollection = Backbone.Collection.extend({
+			    model: ForumPost
+			});
+			var Forum = Backbone.RelationalModel.extend({
+				relations: [{
+					type: Backbone.HasMany,
+					key: 'posts',
+					relatedModel: ForumPost,
+					collectionType: ForumPostCollection,
+					reverseRelation: {
+						key: 'forum',
+						keySource: 'forum_id'
+					}
+				}]
+			});
+			var TestPost = new ForumPost({
+				id: 1, 
+				title: "Hello World",
+				forum: {id: 1, title: "Cupcakes"}
+			});
+
+			var TestForum = Forum.findOrCreate(1);
+
+			notEqual( TestPost.get('forum'), null, "The post's forum is not null" );
+			equal( TestPost.get('forum').get('title'), "Cupcakes", "The post's forum title is Cupcakes" );
+			equal( TestForum.get('title'), "Cupcakes", "A forum of id 1 has the title cupcakes" );
+		});
+
 
 	module( "Backbone.HasOne", { setup: initObjects } );
 		


### PR DESCRIPTION
See #187 regarding this. Basically I just wrote a test case for the modifications that resulted from the discussion in the issue. Allows for a model to be set in the key attribute for a model even if you define keySource.

So with a model with a key of forum and keySource of forum_id with the following values

```
{
id: 1,
title: "Hello World",
forum: {id: 1, title: "Cupcakes}
}
```

and

```
{
id: 1,
title: "Hello World",
forum_id: 1
}
```

Would both work fine.
