### PR TITLE
Fix addModelScope to work with submodels and namespaces.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -254,7 +254,7 @@
 
 			_.find( this._modelScopes || [], function( scope ) {
 				type = _.reduce( parts || [], function( memo, val ) {
-					return memo[ val ];
+					return memo ? memo[ val ] : undefined;
 				}, scope );
 
 				if ( type && type !== scope ) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -395,6 +395,31 @@ $(document).ready(function() {
 			ok( book.relations.length === 1 );
 			ok( book.get( 'pages' ).length === 1 );
 		});
+
+		test( "addModelScope with submodels and namespaces", function() {
+			var ns = {};
+			ns.People = {};
+			Backbone.Relational.store.addModelScope( ns );
+
+			ns.People.Person = Backbone.RelationalModel.extend({
+				subModelTypes: {
+					'Student': 'People.Student'
+				},
+				iam: function() { return "I am an abstract person"; }
+			});
+
+			ns.People.Student = ns.People.Person.extend({
+				iam: function() { return "I am a student"; }
+			});
+
+			ns.People.PersonCollection = Backbone.Collection.extend({
+				model: ns.People.Person
+			})
+
+			var people = new ns.People.PersonCollection([{name: "Bob", type: "Student"}]);
+
+			ok( people.at(0).iam() == "I am a student" );
+		});
 		
 		test( "Models are created from objects, can then be found, destroyed, cannot be found anymore", function() {
 			var houseId = 'house-10';


### PR DESCRIPTION
`addModelScope` does not work when using `subModelTypes` and namespacing in the scope. I believe the test details what I was trying to do, and the fix is a simple one line change.
