### PR TITLE
Another attempt at AMD/CommonJS compatibility

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -6,26 +6,24 @@
  * For details and documentation: https://github.com/PaulUithol/Backbone-relational.
  * Depends on Backbone (and thus on Underscore as well): https://github.com/documentcloud/backbone.
  */
-( function( undefined ) {
+ (function(root, factory) {
+  // Set up Backbone-relational appropriately for the environment.
+  if (typeof exports !== 'undefined') {
+    // Node/CommonJS
+    var Backbone = require('backbone');
+    factory(root, Backbone, require('underscore'), Backbone);
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD
+    define(['underscore', 'backbone'], function(_, Backbone) {
+      return factory(root, Backbone, _, Backbone);
+    });
+  } else {
+    // Browser globals
+    factory(root, root, root._, root.Backbone);
+  }
+}(this, function(root, exports, _, Backbone) {
 	"use strict";
 	
-	/**
-	 * CommonJS shim
-	 **/
-	var _, Backbone, exports;
-	// Support loading requirements using `require` compatible implementations.
-	// In server environments, `window` is not defined; in browser environments, check for the presence of `require`.
-	if ( typeof window === 'undefined' || typeof require !== 'undefined' ) {
-		_ = require( 'underscore' );
-		Backbone = require( 'backbone' );
-		exports = module.exports = Backbone;
-	}
-	else {
-		_ = window._;
-		Backbone = window.Backbone;
-		exports = window;
-	}
-
 	Backbone.Relational = {
 		showWarnings: true
 	};
@@ -1703,4 +1701,6 @@
 
 		return child;
 	};
-})();
+    
+    return Backbone;
+}));


### PR DESCRIPTION
Related to pull #215, I took a look at how support for require.js was added in [amdjs/backbone](https://github.com/amdjs/backbone) and tried to recreate the same technique here.

I don't know if this is the best solution, but I thought it might be useful to consider. I've tested it with my requirejs setup and it seems to work, but I can't vouch for the other environments.
