### PR TITLE
specifying backbone 0.9.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Backbone-relational depends on [backbone](https://github.com/documentcloud/backb
 <script type="text/javascript" src="./js/backbone-relational.js"></script>
 ```
 
-Backbone-relational has been tested with Backbone 0.9.9 (or newer) and Underscore 1.4.3 (or newer).
+Backbone-relational has been tested with Backbone 0.9.10 (or newer) and Underscore 1.4.3 (or newer).
 
 
 ## <a name="backbone-relation"/>Backbone.Relation options


### PR DESCRIPTION
(since it doesn't seem like we're trying to have `master` work in older versions of backbone)
