### PR TITLE
Fix to Register() function to remove old model before trying to add new one

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -342,10 +342,7 @@
 
 			if ( coll ) {
 				if ( coll.get( model ) ) {
-					if ( Backbone.Relational.showWarnings && typeof console !== 'undefined' ) {
-						console.warn( 'Duplicate id! Old RelationalModel:%o, New RelationalModel:%o', coll.get( model ), model );
-					}
-					throw new Error( "Cannot instantiate more than one Backbone.RelationalModel with the same id per type!" );
+					coll.remove(coll.where({id: model.id})[0]);
 				}
 
 				var modelColl = model.collection;


### PR DESCRIPTION
In the register method, it checks if the model already exists in the collection and then throws an error if it does. I was having trouble with this as it caused my code to break, so I instead make it remove the old model if it's there, then it adds the new one just fine.
