### PR TITLE
Updated options fetchRelated() passed to Collection#fetch()

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1235,7 +1235,7 @@
 							url: setUrl
 						},
 						options,
-						{ add: true }
+						{ update: true, remove: false }
 					);
 
 					requests = [ rel.related.fetch( opts ) ];


### PR DESCRIPTION
add: true didn't seem to do anything. Collection.fetch() only checks for updated. Only if it exists, does Collection.update() get called, which then checks for add option... but it defaults to true anyways. I'm presuming that this is a bug and update: true was intended. 

Additionally, I added  emove: false to prevent Collection#update() from removing existing models. This is important if some models were grabbed from cache and other models relied on fetchRelated() calling fetch(). If remove != false, then the cached models would be removed

For example, if you do:

```
ParentCollection.reset([{id: 1, children: [{id: 1}, {id: 2}]}, {id: 2, children: [{id: 1}, {id: 2}, {id: 3}]}]);
```

where:

```
ParentCollection.model = Parent

Parent.relations = {type: hasmany, key: 'children', relatedModel: Child, createModels: false, fetchRelated: true, collectionType: Children}

Children.url = function (multipleModels) {}
```

Then, BB Relational will, eventually:

Create Child objects for id 1 and id 2, but not add them to the Parent[id=1].children collection, then send a Parent[id=1].children.fetch() request off. The return will be parsed and added to the collection.

Asynchronously, fetchRelated() is called for Parent[id=2], which already has children id=1, and id=2 added (though pre-fetch). It loops through and determines that only child id=3 needs to be fetched, so it sends the fetch request off. But, without update: true, then fetch() calls reset(), which will wipe everything out. Without remove: false, then fetc() calls update() which will remove all items not added, essentialy acting like reset.
