### PR TITLE
keyIds should not contain null-entries

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -973,8 +973,11 @@
 				// Handle cases the an API/user supplies just an Object/id instead of an Array
 				this.keyContents = _.isArray( keyContents ) ? keyContents : [ keyContents ];
 
-				this.keyIds = _.map( this.keyContents, function( item ) {
-					return Backbone.Relational.store.resolveIdForItem( this.relatedModel, item );
+				_.each( this.keyContents, function( item ) {
+					var itemId = Backbone.Relational.store.resolveIdForItem( this.relatedModel, item );
+					if ( itemId || itemId === 0) {
+						this.keyIds.push(itemId);
+					}
 				}, this );
 			}
 		},

--- a/test/tests.js
+++ b/test/tests.js
@@ -2301,7 +2301,9 @@ $(document).ready(function() {
 		test( "Cloned instances of persisted models should not be added to any existing collections", function() {
 			var addedModels = 0;
 			
-			var zoo = new window.Zoo();
+			var zoo = new window.Zoo({
+				visitors : [ { name : "Incognito" } ]
+			});
 			
 			var visitor = new window.Visitor({
 				id : 0


### PR DESCRIPTION
- this is especially relevant when new models with null-ids are matched
  against keyIds and a false-match (null === null) is found
