### PR TITLE
Trigger a 'collision' event when there's an collision by ids.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -424,6 +424,9 @@
 		*/
 		update: function( model ) {
 			var coll = this.getCollection( model );
+			var other = coll.get( model );
+			if (other && other !== model)
+				model.trigger('collision', other);
 			coll._onModelEvent( 'change:' + model.idAttribute, model, coll );
 		},
 


### PR DESCRIPTION
This is to open a discussion whether there's really a bug here, and if so, how to fix it.
This patch is what I'm currently using to resolve the issue, but it might not be a good general solution.

The problem:
BBR claims to rely on keeping only a single instance of each model in it's own storage collections.  However, in at least one case, it would silently replace a model with a newer copy. This causes problems since the orphaned "old" copy can still be alive in other collections.  BBR will now at least trigger a 'collision' event when this happens, which allows users to handle the collision intelligently, e.g. by destroying the old copy.

This collision can arise from the following sequence:

```
a = new MyRelationalModel() // This object starts with no id.
b = new MyRelationalModel({'id': 42})  // This object starts with an id of 42.
a.set('id', 42)
```

Should this be allowed to happen?  Doesn't this violate some fundamental assumptions made by BBR?  What should happen in this case?  This patch takes the approach that only the model itself will know how to appropriately resolve the conflict.

Let me know if you'd like more detail.
