### PR TITLE
When using dotNotation, return null if the path cannot be expanded

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1329,6 +1329,7 @@
 			// Go through all splits and return the final result
 			var splits = attr.split( '.' );
 			var result = _.reduce(splits, function( model, split ) {
+				if (_.isNull(model) || _.isUndefined(model)) { return; }  // Return undefined if the path cannot be expanded
 				if ( !( model instanceof Backbone.Model ) ) {
 					throw new Error( 'Attribute must be an instanceof Backbone.Model. Is: ' + model + ', currentSplit: ' + split );
 				}

--- a/test/tests.js
+++ b/test/tests.js
@@ -1671,6 +1671,7 @@ $(document).ready(function() {
 			ok( person.get( 'normal' ) === true, "getting normal attributes works as usual" );
 			ok( person.get( 'user.name' ) === "John", "attributes of nested models can be get via dot notation: nested.attribute");
 			ok(oldCompany.get( 'ceo.name' ) === undefined, "no dotNotation when not enabled");
+			ok( person.get( 'user.fake.attribute') === undefined, "undefined when path doesn't exist");
 			raises( function() {
 				person.get( 'user.over' );
 			}, "getting ambiguous nested attributes raises an exception");


### PR DESCRIPTION
This is a small change to have dotNotation return null when the full path cannot be evaluated (instead of throwing an exception, as it does now).  Our use case for this is Backbone-relational with Rivet.js for databinding.  For example, we have:

```
 %a{data-bind-href: 'item.id | conversation_link', data-bind-text: 'item.assignee.name'}
```

Not all items are assigned, so the current implementation breaks.  This change just leaves the text blank.
