### PR TITLE
Issue with updating keySource field

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -3933,6 +3933,89 @@ $(document).ready(function() {
 		});
 
 
+	module( "Regression", { setup: reset } );
+
+
+		test( "Catching case", function() {
+			var SubModel = Backbone.RelationalModel.extend({
+				idAttribute: 'id'
+			});
+
+			var Model = Backbone.RelationalModel.extend({
+				idAttribute: 'id',
+
+				relations: [{
+					type: Backbone.HasOne,
+					key: 'submodel',
+					keySource: 'sub_data',
+					relatedModel: SubModel,
+					includeInJSON: false
+				}]
+			});
+
+			var inst = new Model( {'id': 123} );
+
+			// set called from fetch
+			inst.set({
+				'id': 123,
+				'some_field': 'some_value',
+				'sub_data': {
+					'id': 321,
+					'key': 'value'
+				},
+				'to_unset': 'unset value'
+			});
+
+			ok( inst.get('submodel').get('key') == 'value', "value of submodule.key should be 'value'" );
+			inst.set({'to_unset': ''}, {'unset': true});
+			ok( inst.get('submodel').get('key') == 'value', "after unset value of submodule.key should be still 'value'" );
+		});
+
+		test( "Source of problem", function() {
+			var SubModel = Backbone.RelationalModel.extend({
+				idAttribute: 'id'
+			});
+
+			var Model = Backbone.RelationalModel.extend({
+				idAttribute: 'id',
+
+				relations: [{
+					type: Backbone.HasOne,
+					key: 'submodel',
+					keySource: 'sub_data',
+					relatedModel: SubModel,
+					includeInJSON: false
+				}]
+			});
+
+			var inst = new Model({
+				'id': 123,
+				'some_field': 'some_value',
+				'sub_data': {
+					'id': 321,
+					'key': 'value'
+				},
+				'to_unset': 'unset value'
+			});
+
+			ok( typeof inst.get('sub_data') == 'undefined', "keySource field should be removed from model" );
+			ok( typeof inst.get('submodel') != 'undefined', "key field should be added..." );
+			ok( inst.get('submodel') instanceof SubModel , "... and should be model instance" );
+
+			// set called from fetch
+			inst.set({
+				'sub_data': {
+					'id': 321,
+					'key': 'value2'
+				},
+			});
+
+			ok( typeof inst.get('sub_data') == 'undefined',  "keySource field should be removed from model" );
+			ok( typeof inst.get('submodel') != 'undefined',  "key field should be present..." );
+			ok( inst.get('submodel').get('key') == 'value2', "... and should be updated" );
+		});
+
+
 	module( "Performance", { setup: reset } );
 
 


### PR DESCRIPTION
There is an issue with updating source field of relation. While initializing source field is removed and relation field appears. But updating will not remove source field and may cause future problems. I've created 2 test cases to show this issue. One is case when i get problem and second is case that displays a source of a problem.
I'm not so familiar with BR internals yet and I'm not sure with fix. But will propose: in updateRelations to check if keySource != key and typeof attributes[keySource] != 'undefined' then update model and delete attributes[keySource]. Smth like this.
