### PR TITLE
Failing test: merge should trigger appropriate change events

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -3561,9 +3561,13 @@ $(document).ready(function() {
 			ok( node2.get( 'parent' ) === node1 );
 			ok( !node1.get( 'parent' ) );
 
+			var changes = 0;
+			node1.on( 'change:parent', function() { changes++; } );
+
 			nodeList.reset( [ { id: 1, parent: 2 } ] );
 
 			ok( node1.get( 'parent' ) === node2 );
+			equal( changes, 1, 'Merge should trigger appropriate change events' );
 		});
 
 		test( "add/remove/update (with `add`, `remove` and `merge` options)", function() {


### PR DESCRIPTION
A slight tweak to the test you added in https://github.com/PaulUithol/Backbone-relational/commit/77eb89d9da345061d06aef87154328a867d536f1 shows a failing behavior.

Just like the original bug, this test passes if you change `reset` to `set`, though I don't see why it shouldn't work fine in either case.
