### PR TITLE
add browserify support

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -14,7 +14,7 @@
 	 * CommonJS shim
 	 **/
 	var _, Backbone, exports;
-	if ( typeof window === 'undefined' ) {
+	if ( typeof window === 'undefined' || ( typeof process !== 'undefined' && process.browser ) ) {
 		_ = require( 'underscore' );
 		Backbone = require( 'backbone' );
 		exports = module.exports = Backbone;


### PR DESCRIPTION
add support for https://github.com/substack/node-browserify . the implementation is specific to browserify (checks if ´process.browser` is set) to avoid issues with other frameworks

the test _Backbone.RelationalModel: change events should not fire on new items in Collection#set_ was failing (newest chrome, windows 8) when i forked the repo, so that's not my fault.
