### PR TITLE
Failing test case where BBR drops a 'change' event.

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -3975,6 +3975,23 @@ $(document).ready(function() {
 			ok( changeEventsTriggered == 1, "Exactly one change event was triggered (triggered " + changeEventsTriggered + " events)" );
 		});
 
+		test( "triggers appropriate change events even when callbacks have triggered set with an unchanging value", function() {
+			var house = new House({
+				id: 'house-100',
+				location: 'in the middle of the street',
+			});
+
+			var changeEventsTriggered = 0;
+
+			house.on('change:location', function() {
+			  house.set({location: 'somewhere else'});
+			}).on( 'change', function () {
+			  changeEventsTriggered++;
+			});
+			house.set({location: 'somewhere else'});
+
+			ok(changeEventsTriggered > 0);
+		  });
 
 	module( "Performance", { setup: reset } );
 


### PR DESCRIPTION
This demonstrates that BBR is silently swallowing 'change' events in some scenarios.

This is caused by BBR deferral of change events and the delay of checking model.hasChanged() until after other, non-deferred events (which may reset changedAttributes) have been triggered.  Fundamentally, Backbone docs say that hasChanged() will only be valid within the callbacks triggered by change events, but BBR is calling hasChanged() from outside those callbacks, so this shouldn't be expected to work correctly.
