### PR TITLE
pass-through options to Backbone.Store#unregister when called as listener to models 'destroy'

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -422,10 +422,10 @@
 		 * Remove a 'model' from the store.
 		 * @param {Backbone.RelationalModel} model
 		 */
-		unregister: function( model ) {
+		unregister: function( model, collection, options ) {
 			this.stopListening( model, 'destroy', this.unregister );
 			var coll = this.getCollection( model );
-			coll && coll.remove( model );
+			coll && coll.remove( model, options );
 		},
 
 		/**


### PR DESCRIPTION
When ´unregister´ gets called as callback on models ´destroy´ event it currently does swallow a possible ´options´ argument supplied when calling ´Model.destroy´.
This pull request simply forwards a possible ´options´ argument so that it may be used further down in the call-chain.
