### PR TITLE
sort event should also be queued when the add event is queued

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1827,7 +1827,7 @@
 			return trigger.apply( this, arguments );
 		}
 
-		if ( eventName === 'add' || eventName === 'remove' || eventName === 'reset' ) {
+		if ( eventName === 'add' || eventName === 'remove' || eventName === 'reset' || eventName === 'sort' ) {
 			var dit = this,
 				args = arguments;
 			

--- a/test/tests.js
+++ b/test/tests.js
@@ -2902,6 +2902,27 @@ $(document).ready(function() {
 			equal( indexes[1], 1, "Second item has index 1" );
 		});
 
+
+        test( "Sort event should be fired after the add event that caused it, even when using 'set'", function() {
+            var zoo = new Zoo();
+            var animals = zoo.get('animals');
+            var events = [];
+
+            animals.comparator = 'id';
+
+            animals.on('add', function() { events.push('add'); });
+            animals.on('sort', function() { events.push('sort'); });
+
+            zoo.set('animals' , [
+                {id : 'lion-2'},
+                {id : 'lion-1'}
+            ]);
+
+            equal(animals.at(0).id, 'lion-1');
+            deepEqual(events, ['add', 'sort', 'add', 'sort']);
+        });
+
+
 		test( "The 'collectionKey' options is used to create references on generated Collections back to its RelationalModel", function() {
 			var zoo = new Zoo({
 				animals: [ 'lion-1', 'zebra-1' ]


### PR DESCRIPTION
In backbone, calling 'add' on a collection while cause a sort event to trigger after the add event. 
However, in some cases, backbone-relational defers the add event to the eventQueue. 
In those cases the sort event should also be deferred so it is triggered after the add event that caused it.
