### PR TITLE
"ReferenceError: module is not defined" in nodejs/requirejs environment

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -17,7 +17,8 @@
 	if ( typeof window === 'undefined' ) {
 		_ = require( 'underscore' );
 		Backbone = require( 'backbone' );
-		exports = module.exports = Backbone;
+		exports = Backbone;
+		typeof module === 'undefined' || (module.exports = exports);
 	}
 	else {
 		_ = window._;


### PR DESCRIPTION
My setups use Backbone-relational within nodejs/requirejs environment.

Without proposed diff, loading of Backbone-relational as a requirejs module leads to:

Error: Evaluating /home/user/project1/public/modules/lib/backbone-relational.js as module "backbone-relational" failed with error: ReferenceError: module is not defined
    at Function.req.load (/home/user/project1/node_modules/requirejs/bin/r.js:2430:23)
    at Object.context.load (/home/user/project1/node_modules/requirejs/bin/r.js:1838:21)
    at Object.Module.load (/home/user/project1/node_modules/requirejs/bin/r.js:1044:29)
    at Object.Module.fetch (/home/user/project1/node_modules/requirejs/bin/r.js:1034:66)
    at Object.Module.check (/home/user/project1/node_modules/requirejs/bin/r.js:1064:26)
    at Object.Module.enable (/home/user/project1/node_modules/requirejs/bin/r.js:1356:22)
    at Object.context.enable (/home/user/project1/node_modules/requirejs/bin/r.js:1710:39)
    at Object.<anonymous> (/home/user/project1/node_modules/requirejs/bin/r.js:1341:33)
    at g (/home/user/project1/node_modules/requirejs/bin/r.js:363:23)
    at each (/home/user/project1/node_modules/requirejs/bin/r.js:291:31)
