### PR TITLE
Fix for "Using parse: true causes unexpected behavior (bug)"

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1638,7 +1638,7 @@
 		findOrCreate: function( attributes, options ) {
 			options || ( options = {} );
 			var parsedAttributes = ( _.isObject( attributes ) && options.parse && this.prototype.parse ) ?
-				this.prototype.parse( attributes ) : attributes;
+				this.prototype.parse( _.clone( attributes ) ) : attributes;
 
 			// Try to find an instance of 'this' model type in the store
 			var model = Backbone.Relational.store.find( this, parsedAttributes );

--- a/test/tests.js
+++ b/test/tests.js
@@ -814,6 +814,21 @@ $(document).ready(function() {
 			delete window.Primate;
 			delete window.Carnivore;
 		});
+
+		test( "findOrCreate does not modify attributes hash if parse is used, prior to creating new model", function () {
+			var model = Backbone.RelationalModel.extend({
+				parse: function( response ) {
+					response.id = response.id + 'something';
+					return response;
+				}
+			});
+			var attributes = {id: 42, foo: "bar"};
+			var testAttributes = {id: 42, foo: "bar"};
+
+			model.findOrCreate( attributes, { parse: true, merge: false, create: false } );
+
+			ok( _.isEqual( attributes, testAttributes ), "attributes hash should not be modified" );
+		});
 		
 
 	module( "Backbone.RelationalModel", { setup: initObjects } );


### PR DESCRIPTION
This is a PR which fixes the issue outlined in PaulUithol/Backbone-relational#336
- using clone to prevent modification of original attributes hash
- adding test to cover this scenario

I've tried to adhere to the coding standard of the codebase, if I should change anything, please let me know.
