### PR TITLE
Backbone.BlockingQueue.process() copies/resets the queue before proceing

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -86,9 +86,21 @@
 			}
 		},
 
+		// Some of the queued events may trigger other blocking events. By
+		// copying the queue here it allows queued events to process closer to
+		// the natural order.
+		//
+		// queue events [ 'A', 'B', 'C' ]
+		// A handler of 'B' triggers 'D' and 'E'
+		// By copying `this._queue` this executes:
+		// [ 'A', 'B', 'D', 'E', 'C' ]
+		// The same order the would have executed if they didn't have to be
+		// delayed and queued.
 		process: function() {
-			while ( this._queue && this._queue.length ) {
-				this._queue.shift()();
+			var queue = this._queue;
+			this._queue = [];
+			while ( queue && queue.length ) {
+				queue.shift()();
 			}
 		},
 


### PR DESCRIPTION
This maintains the originally intended order of events when process gets
called more than once.
# Previous Behavior

process() starts with events ['A1', 'A2', 'A3']. A handler of 'A2' calls
.set() on a model, this ends up queuing 'B1' and 'B2'.

The end of that .set() call starts processing and runs 'A3', 'B1', 'B2'.

final result 'A1', 'A2', 'A3', 'B1', 'B2'
# New Behavior

process() starts with events ['A1', 'A2', 'A3']. A handler of 'A2' calls
.set() on a model, this ends up queuing 'B1' and 'B2'.

The end of that .set() call starts processing and runs 'B1', 'B2'. When
the call stack gets back to the first process() it runs 'A3'

final result 'A1', 'A2',  'B1', 'B2', 'A3'
If the events didn't have to be queued, this is the order they would
have fired in.
