### PR TITLE
Add `relational:unregister` optional event.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -449,6 +449,7 @@
 		 */
 		unregister: function( model, collection, options ) {
 			this.stopListening( model, 'destroy', this.unregister );
+			this.stopListening( model, 'relational:unregister', this.unregister );
 			var coll = this.getCollection( model );
 			coll && coll.remove( model, options );
 		},


### PR DESCRIPTION
This is very useful if you want to destroy a relation by yourself.

This helps Chaplin (http://chaplinjs.org) since we need to dispose all model properties and relations on every next controller action.
