### PR TITLE
Relations can now be a method or a property

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1188,7 +1188,7 @@
 			this.acquire(); // Setting up relations often also involve calls to 'set', and we only want to enter this function once
 			this._relations = {};
 
-			_.each( this.relations || [], function( rel ) {
+			_.each( _.result(this, 'relations') || [], function( rel ) {
 				Backbone.Relational.store.initializeRelation( this, rel, options );
 			}, this );
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -2491,6 +2491,45 @@ $(document).ready(function() {
 			ok( b2.get( 'a' ).id == 'a2' );
 		});
 
+		test( "Can retrieve relations if it's a property or a method", function () {
+			window.Zoo.prototype._relations = window.Zoo.prototype.relations;
+			window.Zoo.prototype.relations = function () {
+				return [
+					{
+						type: Backbone.HasMany,
+						key: 'animals',
+						relatedModel: 'Animal',
+						includeInJSON: [ 'id', 'species' ],
+						collectionType: 'AnimalCollection',
+						collectionOptions: function( instance ) { return { 'url': 'zoo/' + instance.cid + '/animal/' } },
+						reverseRelation: {
+							key: 'livesIn',
+							includeInJSON: [ 'id', 'name' ]
+						}
+					},
+					{ // A simple HasMany without reverse relation
+						type: Backbone.HasMany,
+						key: 'visitors',
+						relatedModel: 'Visitor'
+					}
+				];
+			};
+
+			var animals = new AnimalCollection([
+				{ id: 1, species: 'Lion' },
+				{ id: 2 ,species: 'Zebra' }
+			]);
+
+			var zoo = new Zoo( { animals: animals } );
+
+			equal( zoo.get( 'animals' ), animals, "The 'animals' collection has been set as the zoo's animals" );
+			equal( zoo.get( 'animals' ).length, 2, "Two animals in 'zoo'" );
+
+			zoo.destroy();
+			window.Zoo.prototype.relations = window.Zoo.prototype._relations;
+			delete window.Zoo.prototype._relations;
+		});
+
 
 	module( "Backbone.HasOne", { setup: initObjects } );
 


### PR DESCRIPTION
You have now 2 ways to declare a relation : 

``` javascript
{
    relations: []
}
```

or 

``` javascript
{
    relations: function () {
        return [];
    }
}
```

(I also removed trailing spaces)
