### PR TITLE
relatedModel property as function

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -516,6 +516,13 @@
 		this.relatedModel = this.options.relatedModel;
 		if ( _.isString( this.relatedModel ) ) {
 			this.relatedModel = Backbone.Relational.store.getObjectByName( this.relatedModel );
+		} else if(this.relatedModel.prototype instanceof Backbone.Model === false) {
+			// This makes it possible to pass a function that will be called when the relations are build
+			// Useful for requirejs circular dependencies e.g.:
+			//     relatedModel: function() {
+			//	       return require('model')
+			//     }
+			this.relatedModel = this.options.relatedModel.call();
 		}
 
 		if ( !this.checkPreconditions() ) {


### PR DESCRIPTION
When using requirejs and related Models, you often end up with circular dependencies. In this case it's very difficult to find a clean solution. Giving the opportunity to pass a relatedModel as function can solve this problem. 

This is what happens:
Check if the property is a function (and not an instance of Backbone.Model). Then call it.
Works great with require.js and keeps the code clean.
