### PR TITLE
Check for undefined "rel" in setup() constructor

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1557,6 +1557,9 @@
 
 			// Initialize all reverseRelations that belong to this new model.
 			_.each( this.prototype.relations || [], function( rel ) {
+				if ( !rel ) {
+					return;
+				}
 				if ( !rel.model ) {
 					rel.model = this;
 				}


### PR DESCRIPTION
In setup, around line ~1530, there's a loop over this.prototype.relations. Currently this only checks if rel.model is defined, but should also check if rel is defined.

Case in point: I've just spent the past 4 hours hunting down a bug in IE8, turns out that I had a trailing comma when defining my relations in a model. In IE >=8 this inserts an undefined value at the end of the list, which underscore then passes into that function.
