### PR TITLE
Fix "use master" checkbox in test/index.html

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -17,8 +17,8 @@
 	
 	if ( QUnit.urlParams.master ) {
 		sources = [
-			'https://raw.github.com/documentcloud/underscore/master/underscore.js',
-			'https://raw.github.com/documentcloud/backbone/master/backbone.js'
+			'https://rawgithub.com/documentcloud/underscore/master/underscore.js',
+			'https://rawgithub.com/documentcloud/backbone/master/backbone.js'
 		];
 	}
 	else {


### PR DESCRIPTION
github stopped serving the right content-type, using rawgithub.com proxy instead.
