### PR TITLE
Remove unnecessary locking

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -690,10 +690,7 @@
 		 */
 		setRelated: function( related ) {
 			this.related = related;
-
-			this.instance.acquire();
 			this.instance.attributes[ this.key ] = related;
-			this.instance.release();
 		},
 
 		/**


### PR DESCRIPTION
`setRelated` is still using `acquire()` and `release()`, even though they haven't been necessary since https://github.com/PaulUithol/Backbone-relational/commit/958b5ec20c8a32f084e12f81884c50c2d1b2c960.

All tests pass.
