### PR TITLE
HasMany option to reset the associated collection.

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1023,7 +1023,11 @@
 
 				// By now, both `merge` and `parse` will already have been executed for models if they were specified.
 				// Disable them to prevent additional calls.
-				related.set( toAdd, _.defaults( { merge: false, parse: false }, options ) );
+				if (this.options.reset) {
+					related.reset( toAdd, _.defaults( { parse: false }, options ) );
+				} else {
+					related.set( toAdd, _.defaults( { merge: false, parse: false }, options ) );
+				}
 			}
 
 			// Remove entries from `keyIds` that were already part of the relation (and are thus 'unchanged')


### PR DESCRIPTION
I open this pull request as a discussion to see what you think of the new HasMany option I've added. I've been reading the Backbone-relational source code a few times but I'm still not confident I understand it enough to assess the impact of the change. If you give me a green light I will write additional tests for this feature. Existing tests pass.

In a nutshell what I need is for a related HasMany collection to be **reset**, not updated, when fetching the parent model.

I'm writing a [HAL+JSON library based on Backbone-relational](https://github.com/AlphaHydrae/backbone-relational-hal). This is the kind of data I'm putting in a Backbone-relational model structure:

```json
{
  "property": "value",
  "_embedded": {
    "item": [
      { "name": "foo" },
      { "name": "bar" },
      { "name": "baz" }
    ]
  }
}
```

Basically the relational model looks like this:

```js
var Item = Backbone.RelationalModel.extend({});

var Embedded = Backbone.RelationalModel.extend({
  relations: [
    {
      type: Backbone.HasMany,
      key: "item",
      relatedModel: Item
    }
  ]
});

var Resource = Backbone.RelationalModel.extend({
  relations: [
    {
      type: Backbone.HasOne,
      key: "_embedded",
      relatedModel: Embedded
    }
  ]
});
```

This works fine, but when I call `fetch` on `Resource` and items have changed, the collection in the `item` relation of `Embedded` is updated with `Backbone.Collection#set`. Existing models are updated, new models are added, etc.

This is fine most of the time, but in another project I want to use this collection in a [Backbone.Marionette CollectionView](https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.collectionview.md#collectionview-automatic-rendering). When items change, I need the collection view to be completely re-rendered. This only happens if the collection triggers the `reset` event. So I need Backbone-relational to call `Backbone.Collection#reset`.

I added an optional `reset` option to the HasMany relation:

```js
{
  type: Backbone.HasMany,
  key: "item",
  relatedModel: Item,
  reset: true
}
```

It changes the behavior so that the related collection is always `reset`. This supports my use case and breaks no existing test. It renders the `add`, `merge` and `remove` options useless when set so either an error should be thrown when these options are combined or it should be documented clearly.

Should I go ahead and write tests/documentation or is there something I overlooked in the implementation or another reason you wouldn't want this feature?