### PR TITLE
When adding relations, use a reverse index and one event handler

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -3454,7 +3454,8 @@ $(document).ready(function() {
             ]);
 
             equal(animals.at(0).id, 'lion-1');
-            deepEqual(events, ['add', 'sort', 'add', 'sort']);
+          equal(animals.at(1).id, 'lion-2');
+            deepEqual(events, ['add', 'add', 'sort']);
         });
 
 


### PR DESCRIPTION
Attempts to reduce algorithmic complexity of looking up potential relations added to a model's master collection by requiring only one handler  The code is not ideal in style, and could use some additional test exercising, but demonstrates the idea and has been used in my production app successfully.  
