### PR TITLE
Failing test showing problem with order of nested models

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -1600,7 +1600,38 @@ $(document).ready(function() {
 			equal( modelChangeEvents, 2, 'change event should be triggered' );
 		});
 
-	
+		test( "Model's collection children should be in the proper order during fetch w/remove: false", function() {
+			var Child = Backbone.RelationalModel.extend();
+			var Parent = Backbone.RelationalModel.extend( {
+				relations: [ {
+					type: Backbone.HasMany,
+					key: 'children',
+					relatedModel: Child
+				} ]
+			} );
+
+			// initialize a child... there's no good reason why this should affect the test passing
+			Child.findOrCreate( { id: 'foo1' } );
+
+			// simulate a fetch of the parent with nested children
+			var parent = Parent.findOrCreate( { id: 'the-parent' } );
+			var children = parent.get( 'children' );
+			equal( children.length, 0 );
+			parent.set({
+				id: 'the-parent',
+				children: [
+					{ id: 'foo1' },
+					{ id: 'foo2' }
+				]
+			}, {
+				remove: false // maybe necessary in case you have other relations with isNew models, etc.
+			});
+
+			// check order of parent's children
+			equal( children.length, 2, 'parent is fetched with children' );
+			deepEqual( children.pluck('id'), ['foo1', 'foo2'], 'children are in the right order' );
+		});
+
 	module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup: reset } );
 
 		test( "Object building based on type, when using explicit collections" , function() {


### PR DESCRIPTION
Model's collection children should be in the proper order during fetch w/remove: false, even if one of the children have already been initialized in the Store.

Fetching a Model that has nested models sometimes results in the children being out-of-order.

This test fails, but should pass.

If you remove `{ remove: false }` from the fetch, it passes. However there's no good reason why `remove: false` should cause it to fail, and there other reasons why it could be  important that `remove: false` remains. Also if you remove the initial `Child.findOrCreate` it passes, but this also shouldn't affect the order of the Parent's children.