### PR TITLE
Update backbone-relational.js

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1592,6 +1592,9 @@
 					}
 					else if ( related instanceof Backbone.Model ) {
 						value = related.get( includeInJSON );
+					} else if ( related && ( includeInJSON === rel.relatedModel.prototype.idAttribute )) {
+						// related may contains raw data (like ID or list of IDs if HasMany)
+						value = related;
 					}
 
 					// Add ids for 'unfound' models if includeInJSON is equal to (only) the relatedModel's `idAttribute`


### PR DESCRIPTION
Assume, that I have model Zoo with relation to animals. If I use save() method with `wait: true` to update & save the model and provide new animals as a list of IDs (like `{animals: [1,23,43]}` ), toJSON method in backbone-relations.js fails on `value = value.concat(rel.keyIds)`, because value is null. 

This is because Backbone does not use set() method in save() if wait is True - it's only make a simple copy of provided attributes and set as model's attributes. The relation (that is an attribute of course) is not initialized so is not a model (for HasOne relation), or Collection (for HasMany relation), but contains simple value like Number, String or Array (depends on the type of relation and the data I set), which are keys for relation. 

This pull request fix this bug and add additional check to toJSON method. If relation value is not a model or collection and is not empty assume that is a raw data and should be returned "as is". toJSON method returns list of related object keys, I used a related object keys in attributes object for Backbone.save() method, so everything is OK.
