### PR TITLE
Models referenced in parent only should be fetched on getAsync too. This...

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1433,6 +1433,8 @@
 
 							return model;
 						}, this );
+
+						coll.add(createdModels);
 					};
 
 				// Try if the 'collection' can provide a url to fetch a set of models in one request.

--- a/test/tests.js
+++ b/test/tests.js
@@ -1684,6 +1684,46 @@ $(document).ready(function() {
 			equal( modelChangeEvents, 2, 'change event should be triggered' );
 		});
 
+		test( "getAsync should work for case where child is referenced in parent only", function() {
+			var A = Backbone.RelationalModel.extend({
+				urlRoot: ' ',
+				sync: function(method, model, options) {
+					if (model.get('id') == 'error') {
+						options.error();
+						return;
+					}
+
+					var data = {
+						id: model.attributes.id,
+						name: 'name-' + model.attributes.id
+					};
+
+					options.success(data);
+				}
+			});
+
+			var B = Backbone.RelationalModel.extend({
+				relations: [{
+					type: Backbone.HasMany,
+					key: 'aas',
+					relatedModel: A,
+					autoFetch: true
+				}]
+			});
+
+			var b = new B({
+				aas: ['1', '2', '3']
+			});
+
+			equal( b.get('aas').length, 3, 'all models specified should load' );
+
+			var b2 = new B({
+				aas: ['1', 'error', '3']
+			});
+
+			equal( b2.get('aas').length, 2, 'errored model should be removed from collection' );
+		});
+
 	
 	module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup: reset } );
 


### PR DESCRIPTION
... is necessary in cases where single instance of child model might belong to multiple instances of Parent models at the same time.

This resolves my problem #515