### PR TITLE
Pass options object to Model's parse function

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1827,7 +1827,7 @@
 		findOrCreate: function( attributes, options ) {
 			options || ( options = {} );
 			var parsedAttributes = ( _.isObject( attributes ) && options.parse && this.prototype.parse ) ?
-				this.prototype.parse( _.clone( attributes ) ) : attributes;
+				this.prototype.parse( _.clone( attributes ), options ) : attributes;
 
 			// If specified, use a custom `find` function to match up existing models to the given attributes.
 			// Otherwise, try to find an instance of 'this' model type in the store

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1960,7 +1960,7 @@
 		// Add 'models' in a single batch, so the original add will only be called once (and thus 'sort', etc).
 		// If `parse` was specified, the collection and contained models have been parsed now.
 		toAdd = singular ? ( toAdd.length ? toAdd[ 0 ] : null ) : toAdd;
-		var result = set.call( this, toAdd, _.defaults( { merge: false, parse: false }, options ) );
+		var result = set.call( this, toAdd, _.defaults( { parse: false }, options ) );
 
 		for ( i = 0; i < newModels.length; i++ ) {
 			model = newModels[i];


### PR DESCRIPTION
The Backbone Model's [parse function](http://backbonejs.org/#Model-parse) expects the options object as the second argument.