### PR TITLE
fix for always forcing parse: false when creating a model

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1038,7 +1038,7 @@
 
 				// By now, `parse` will already have been executed just above for models if specified.
 				// Disable to prevent additional calls.
-				related.set( toAdd, _.defaults( { parse: false }, options ) );
+				related.set( toAdd, _.defaults( options, { parse: false } ) );
 			}
 
 			// Remove entries from `keyIds` that were already part of the relation (and are thus 'unchanged')
@@ -1154,7 +1154,7 @@
 			var dit = this;
 			model.queue( function() {
 				if ( dit.related && !dit.related.get( model ) ) {
-					dit.related.add( model, _.defaults( { parse: false }, options ) );
+					dit.related.add( model, _.defaults( options, { parse: false } ) );
 				}
 			});
 		},

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1460,7 +1460,7 @@
 								_.each( createdModels, function( model ) {
 									model.trigger( 'destroy', model, model.collection, options );
 								});
-								
+
 								options.error && options.error.apply( models, arguments );
 							},
 							url: setUrl
@@ -1499,7 +1499,7 @@
 				}
 			);
 		},
-		
+
 		deferArray: function(deferArray) {
 			return Backbone.$.when.apply(null, deferArray);
 		},
@@ -1847,7 +1847,7 @@
 					model.set( parsedAttributes, options );
 				}
 				else if ( !model && options.create !== false ) {
-					model = this.build( parsedAttributes, _.defaults( { parse: false }, options ) );
+					model = this.build( parsedAttributes, _.defaults( options, { parse: false } ) );
 				}
 			}
 

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1038,7 +1038,7 @@
 
 				// By now, `parse` will already have been executed just above for models if specified.
 				// Disable to prevent additional calls.
-				related.set( toAdd, _.defaults( options, { parse: false } ) );
+				related.set( toAdd, _.defaults( options || {}, { parse: false } ) );
 			}
 
 			// Remove entries from `keyIds` that were already part of the relation (and are thus 'unchanged')
@@ -1847,7 +1847,7 @@
 					model.set( parsedAttributes, options );
 				}
 				else if ( !model && options.create !== false ) {
-					model = this.build( parsedAttributes, _.defaults( options, { parse: false } ) );
+					model = this.build( parsedAttributes, _.defaults( options || {}, { parse: false } ) );
 				}
 			}
 
@@ -1963,7 +1963,7 @@
 		// Add 'models' in a single batch, so the original add will only be called once (and thus 'sort', etc).
 		// If `parse` was specified, the collection and contained models have been parsed now.
 		toAdd = singular ? ( toAdd.length ? toAdd[ 0 ] : null ) : toAdd;
-		var result = set.call( this, toAdd, _.defaults( options, { merge: false, parse: false } ) );
+		var result = set.call( this, toAdd, _.defaults( options || {}, { merge: false, parse: false } ) );
 
 		for ( i = 0; i < newModels.length; i++ ) {
 			model = newModels[i];

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1963,7 +1963,7 @@
 		// Add 'models' in a single batch, so the original add will only be called once (and thus 'sort', etc).
 		// If `parse` was specified, the collection and contained models have been parsed now.
 		toAdd = singular ? ( toAdd.length ? toAdd[ 0 ] : null ) : toAdd;
-		var result = set.call( this, toAdd, _.defaults( { merge: false, parse: false }, options ) );
+		var result = set.call( this, toAdd, _.defaults( options, { merge: false, parse: false } ) );
 
 		for ( i = 0; i < newModels.length; i++ ) {
 			model = newModels[i];


### PR DESCRIPTION
{ parse: false } was always being passed when creating a model instead of allowing parse: true by the user when passing in an options object.
There seems to be a few other places where the _.defaults arguments are reversed which may require further fixing.