### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,5 +6,4 @@
     "backbone": ">=1.1.2"
   },
   "ignore": ["static", "test", ".html"],
-  "version": "0.10.0-beta.0"
 }


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property