### PR TITLE
Export extended Backbone object

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1,6 +1,6 @@
 /* vim: set tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab: */
 /**
- * Backbone-relational.js 0.10.0
+ * Backbone-relational.js 0.8.8
  * (c) 2011-2014 Paul Uithol and contributors (https://github.com/PaulUithol/Backbone-relational/graphs/contributors)
  *
  * Backbone-relational may be freely distributed under the MIT license; see the accompanying LICENSE.txt.
@@ -56,19 +56,19 @@
 	}
 	// Finally, as a browser global. Use `root` here as it references `window`.
 	else {
-		factory( root, root.Backbone, root._ );
+		factory( {} , root.Backbone, root._ );
 	}
-}( this, function( exports, Backbone, _ ) {
+}( this, function( module, Backbone, _ ) {
 	"use strict";
 
-	Backbone.Relational = {
+	module.Relational = {
 		showWarnings: true
 	};
 
 	/**
 	 * Semaphore mixin; can be used as both binary and counting.
 	 **/
-	Backbone.Semaphore = {
+	module.Semaphore = {
 		_permitsAvailable: null,
 		_permitsUsed: 0,
 
@@ -107,10 +107,10 @@
 	 * and processes them when unblocked (via 'unblock').
 	 * Process can also be called manually (via 'process').
 	 */
-	Backbone.BlockingQueue = function() {
+	module.BlockingQueue = function() {
 		this._queue = [];
 	};
-	_.extend( Backbone.BlockingQueue.prototype, Backbone.Semaphore, {
+	_.extend( module.BlockingQueue.prototype, module.Semaphore, {
 		_queue: null,
 
 		add: function( func ) {
@@ -159,20 +159,20 @@
 	 * Global event queue. Accumulates external events ('add:<key>', 'remove:<key>' and 'change:<key>')
 	 * until the top-level object is fully initialized (see 'Backbone.RelationalModel').
 	 */
-	Backbone.Relational.eventQueue = new Backbone.BlockingQueue();
+	module.Relational.eventQueue = new module.BlockingQueue();
 
 	/**
 	 * Backbone.Store keeps track of all created (and destruction of) Backbone.RelationalModel.
 	 * Handles lookup for relations.
 	 */
-	Backbone.Store = function() {
+	module.Store = function() {
 		this._collections = [];
 		this._reverseRelations = [];
 		this._orphanRelations = [];
 		this._subModels = [];
-		this._modelScopes = [ exports ];
+		this._modelScopes = [ module ];
 	};
-	_.extend( Backbone.Store.prototype, Backbone.Events, {
+	_.extend( module.Store.prototype, Backbone.Events, {
 		/**
 		 * Create a new `Relation`.
 		 * @param {Backbone.RelationalModel} [model]
@@ -180,12 +180,12 @@
 		 * @param {Object} [options]
 		 */
 		initializeRelation: function( model, relation, options ) {
-			var type = !_.isString( relation.type ) ? relation.type : Backbone[ relation.type ] || this.getObjectByName( relation.type );
-			if ( type && type.prototype instanceof Backbone.Relation ) {
+			var type = !_.isString( relation.type ) ? relation.type : module[ relation.type ] || this.getObjectByName( relation.type );
+			if ( type && type.prototype instanceof module.Relation ) {
 				var rel = new type( model, relation, options ); // Also pushes the new Relation into `model._relations`
 			}
 			else {
-				Backbone.Relational.showWarnings && typeof console !== 'undefined' && console.warn( 'Relation=%o; missing or invalid relation type!', relation );
+				module.Relational.showWarnings && typeof console !== 'undefined' && console.warn( 'Relation=%o; missing or invalid relation type!', relation );
 			}
 		},
 
@@ -290,7 +290,7 @@
 		processOrphanRelations: function() {
 			// Make sure to operate on a copy since we're removing while iterating
 			_.each( this._orphanRelations.slice( 0 ), function( rel ) {
-				var relatedModel = Backbone.Relational.store.getObjectByName( rel.relatedModel );
+				var relatedModel = module.Relational.store.getObjectByName( rel.relatedModel );
 				if ( relatedModel ) {
 					this.initializeRelation( null, rel );
 					this._orphanRelations = _.without( this._orphanRelations, rel );
@@ -337,7 +337,7 @@
 		 * @return {Backbone.Collection} A collection if found (or applicable for 'model'), or null
 		 */
 		getCollection: function( type, create ) {
-			if ( type instanceof Backbone.RelationalModel ) {
+			if ( type instanceof module.RelationalModel ) {
 				type = type.constructor;
 			}
 
@@ -383,12 +383,12 @@
 			var coll;
 
 			// If 'type' is an instance, take its constructor
-			if ( type instanceof Backbone.RelationalModel ) {
+			if ( type instanceof module.RelationalModel ) {
 				type = type.constructor;
 			}
 
 			// Type should inherit from Backbone.RelationalModel.
-			if ( type.prototype instanceof Backbone.RelationalModel ) {
+			if ( type.prototype instanceof module.RelationalModel ) {
 				coll = new Backbone.Collection();
 				coll.model = type;
 
@@ -408,7 +408,7 @@
 			var id = _.isString( item ) || _.isNumber( item ) ? item : null;
 
 			if ( id === null ) {
-				if ( item instanceof Backbone.RelationalModel ) {
+				if ( item instanceof module.RelationalModel ) {
 					id = item.id;
 				}
 				else if ( _.isObject( item ) ) {
@@ -470,7 +470,7 @@
 				duplicate = coll && coll.get( id );
 
 			if ( duplicate && model !== duplicate ) {
-				if ( Backbone.Relational.showWarnings && typeof console !== 'undefined' ) {
+				if ( module.Relational.showWarnings && typeof console !== 'undefined' ) {
 					console.warn( 'Duplicate id! Old RelationalModel=%o, new RelationalModel=%o', duplicate, model );
 				}
 
@@ -555,10 +555,10 @@
 
 			this._collections = [];
 			this._subModels = [];
-			this._modelScopes = [ exports ];
+			this._modelScopes = [ module ];
 		}
 	});
-	Backbone.Relational.store = new Backbone.Store();
+	module.Relational.store = new module.Store();
 
 	/**
 	 * The main Relation class, from which 'HasOne' and 'HasMany' inherit. Internally, 'relational:<key>' events
@@ -576,15 +576,15 @@
 	 *    {Backbone.Relation|String} type ('HasOne' or 'HasMany').
 	 * @param {Object} opts
 	 */
-	Backbone.Relation = function( instance, options, opts ) {
+	module.Relation = function( instance, options, opts ) {
 		this.instance = instance;
 		// Make sure 'options' is sane, and fill with defaults from subclasses and this object's prototype
 		options = _.isObject( options ) ? options : {};
 		this.reverseRelation = _.defaults( options.reverseRelation || {}, this.options.reverseRelation );
-		this.options = _.defaults( options, this.options, Backbone.Relation.prototype.options );
+		this.options = _.defaults( options, this.options, module.Relation.prototype.options );
 
 		this.reverseRelation.type = !_.isString( this.reverseRelation.type ) ? this.reverseRelation.type :
-			Backbone[ this.reverseRelation.type ] || Backbone.Relational.store.getObjectByName( this.reverseRelation.type );
+			module[ this.reverseRelation.type ] || module.Relational.store.getObjectByName( this.reverseRelation.type );
 
 		this.key = this.options.key;
 		this.keySource = this.options.keySource || this.key;
@@ -594,19 +594,12 @@
 
 		this.relatedModel = this.options.relatedModel;
 
-		// No 'relatedModel' is interpreted as self-referential
-		if ( _.isUndefined( this.relatedModel ) ) {
-			this.relatedModel = this.model;
-		}
-
-		// Otherwise, try to resolve the given value to an object
-		if ( _.isFunction( this.relatedModel ) && !( this.relatedModel.prototype instanceof Backbone.RelationalModel ) ) {
+		if ( _.isFunction( this.relatedModel ) && !( this.relatedModel.prototype instanceof module.RelationalModel ) ) {
 			this.relatedModel = _.result( this, 'relatedModel' );
 		}
 		if ( _.isString( this.relatedModel ) ) {
-			this.relatedModel = Backbone.Relational.store.getObjectByName( this.relatedModel );
+			this.relatedModel = module.Relational.store.getObjectByName( this.relatedModel );
 		}
-
 
 		if ( !this.checkPreconditions() ) {
 			return;
@@ -614,7 +607,7 @@
 
 		// Add the reverse relation on 'relatedModel' to the store's reverseRelations
 		if ( !this.options.isAutoRelation && this.reverseRelation.type && this.reverseRelation.key ) {
-			Backbone.Relational.store.addReverseRelation( _.defaults( {
+			module.Relational.store.addReverseRelation( _.defaults( {
 					isAutoRelation: true,
 					model: this.relatedModel,
 					relatedModel: this.model,
@@ -631,7 +624,7 @@
 			}
 
 			this.setKeyContents( this.instance.get( contentKey ) );
-			this.relatedCollection = Backbone.Relational.store.getCollection( this.relatedModel );
+			this.relatedCollection = module.Relational.store.getCollection( this.relatedModel );
 
 			// Explicitly clear 'keySource', to prevent a leaky abstraction if 'keySource' differs from 'key'.
 			if ( this.keySource !== this.key ) {
@@ -654,9 +647,9 @@
 		}
 	};
 	// Fix inheritance :\
-	Backbone.Relation.extend = Backbone.Model.extend;
+	module.Relation.extend = Backbone.Model.extend;
 	// Set up all inheritable **Backbone.Relation** properties and methods.
-	_.extend( Backbone.Relation.prototype, Backbone.Events, Backbone.Semaphore, {
+	_.extend( module.Relation.prototype, Backbone.Events, module.Semaphore, {
 		options: {
 			createModels: true,
 			includeInJSON: true,
@@ -682,24 +675,24 @@
 				k = this.key,
 				m = this.model,
 				rm = this.relatedModel,
-				warn = Backbone.Relational.showWarnings && typeof console !== 'undefined';
+				warn = module.Relational.showWarnings && typeof console !== 'undefined';
 
 			if ( !m || !k || !rm ) {
 				warn && console.warn( 'Relation=%o: missing model, key or relatedModel (%o, %o, %o).', this, m, k, rm );
 				return false;
 			}
 			// Check if the type in 'model' inherits from Backbone.RelationalModel
-			if ( !( m.prototype instanceof Backbone.RelationalModel ) ) {
+			if ( !( m.prototype instanceof module.RelationalModel ) ) {
 				warn && console.warn( 'Relation=%o: model does not inherit from Backbone.RelationalModel (%o).', this, i );
 				return false;
 			}
 			// Check if the type in 'relatedModel' inherits from Backbone.RelationalModel
-			if ( !( rm.prototype instanceof Backbone.RelationalModel ) ) {
+			if ( !( rm.prototype instanceof module.RelationalModel ) ) {
 				warn && console.warn( 'Relation=%o: relatedModel does not inherit from Backbone.RelationalModel (%o).', this, rm );
 				return false;
 			}
 			// Check if this is not a HasMany, and the reverse relation is HasMany as well
-			if ( this instanceof Backbone.HasMany && this.reverseRelation.type === Backbone.HasMany ) {
+			if ( this instanceof module.HasMany && this.reverseRelation.type === module.HasMany ) {
 				warn && console.warn( 'Relation=%o: relation is a HasMany, and the reverseRelation is HasMany as well.', this );
 				return false;
 			}
@@ -748,21 +741,14 @@
 		getReverseRelations: function( model ) {
 			var reverseRelations = [];
 			// Iterate over 'model', 'this.related.models' (if this.related is a Backbone.Collection), or wrap 'this.related' in an array.
-			var models = !_.isUndefined( model ) ? [ model ] : this.related && ( this.related.models || [ this.related ] ),
-				relations = null,
-				relation = null;
-
-			for( var i = 0; i < ( models || [] ).length; i++ ) {
-				relations = models[ i ].getRelations() || [];
-
-				for( var j = 0; j < relations.length; j++ ) {
-					relation = relations[ j ];
-
+			var models = !_.isUndefined( model ) ? [ model ] : this.related && ( this.related.models || [ this.related ] );
+			_.each( models || [], function( related ) {
+				_.each( related.getRelations() || [], function( relation ) {
 					if ( this._isReverseRelation( relation ) ) {
 						reverseRelations.push( relation );
 					}
-				}
-			}
+				}, this );
+			}, this );
 
 			return reverseRelations;
 		},
@@ -774,10 +760,10 @@
 		destroy: function() {
 			this.stopListening();
 
-			if ( this instanceof Backbone.HasOne ) {
+			if ( this instanceof module.HasOne ) {
 				this.setRelated( null );
 			}
-			else if ( this instanceof Backbone.HasMany ) {
+			else if ( this instanceof module.HasMany ) {
 				this.setRelated( this._prepareCollection() );
 			}
 
@@ -787,7 +773,7 @@
 		}
 	});
 
-	Backbone.HasOne = Backbone.Relation.extend({
+	module.HasOne = module.Relation.extend({
 		options: {
 			reverseRelation: { type: 'HasMany' }
 		},
@@ -836,7 +822,7 @@
 		 */
 		setKeyContents: function( keyContents ) {
 			this.keyContents = keyContents;
-			this.keyId = Backbone.Relational.store.resolveIdForItem( this.relatedModel, this.keyContents );
+			this.keyId = module.Relational.store.resolveIdForItem( this.relatedModel, this.keyContents );
 		},
 
 		/**
@@ -881,7 +867,7 @@
 			if ( !options.silent && this.related !== oldRelated ) {
 				var dit = this;
 				this.changed = true;
-				Backbone.Relational.eventQueue.add( function() {
+				module.Relational.eventQueue.add( function() {
 					dit.instance.trigger( 'change:' + dit.key, dit.instance, dit.related, options, true );
 					dit.changed = false;
 				});
@@ -925,7 +911,7 @@
 		}
 	});
 
-	Backbone.HasMany = Backbone.Relation.extend({
+	module.HasMany = module.Relation.extend({
 		collectionType: null,
 
 		options: {
@@ -944,7 +930,7 @@
 				this.collectionType = _.result( this, 'collectionType' );
 			}
 			if ( _.isString( this.collectionType ) ) {
-				this.collectionType = Backbone.Relational.store.getObjectByName( this.collectionType );
+				this.collectionType = module.Relational.store.getObjectByName( this.collectionType );
 			}
 			if ( this.collectionType !== Backbone.Collection && !( this.collectionType.prototype instanceof Backbone.Collection ) ) {
 				throw new Error( '`collectionType` must inherit from Backbone.Collection' );
@@ -978,7 +964,7 @@
 				var key = this.options.collectionKey === true ? this.options.reverseRelation.key : this.options.collectionKey;
 
 				if ( collection[ key ] && collection[ key ] !== this.instance ) {
-					if ( Backbone.Relational.showWarnings && typeof console !== 'undefined' ) {
+					if ( module.Relational.showWarnings && typeof console !== 'undefined' ) {
 						console.warn( 'Relation=%o; collectionKey=%s already exists on collection=%o', this, key, this.options.collectionKey );
 					}
 				}
@@ -1022,8 +1008,9 @@
 					}
 					else {
 						// If `merge` is true, update models here, instead of during update.
-						model = ( _.isObject( attributes ) && options.parse && this.relatedModel.prototype.parse ) ?
-							this.relatedModel.prototype.parse( _.clone( attributes ), options ) : attributes;
+						model = this.relatedModel.findOrCreate( attributes,
+							_.extend( { merge: true }, options, { create: this.options.createModels } )
+						);
 					}
 
 					model && toAdd.push( model );
@@ -1036,9 +1023,9 @@
 					related = this._prepareCollection();
 				}
 
-				// By now, `parse` will already have been executed just above for models if specified.
-				// Disable to prevent additional calls.
-				related.set( toAdd, _.defaults( { parse: false }, options ) );
+				// By now, both `merge` and `parse` will already have been executed for models if they were specified.
+				// Disable them to prevent additional calls.
+				related.set( toAdd, _.defaults( { merge: false, parse: false }, options ) );
 			}
 
 			// Remove entries from `keyIds` that were already part of the relation (and are thus 'unchanged')
@@ -1060,7 +1047,7 @@
 				this.keyContents = _.isArray( keyContents ) ? keyContents : [ keyContents ];
 
 				_.each( this.keyContents, function( item ) {
-					var itemId = Backbone.Relational.store.resolveIdForItem( this.relatedModel, item );
+					var itemId = module.Relational.store.resolveIdForItem( this.relatedModel, item );
 					if ( itemId || itemId === 0 ) {
 						this.keyIds.push( itemId );
 					}
@@ -1082,7 +1069,7 @@
 
 			if ( !options.silent ) {
 				var dit = this;
-				Backbone.Relational.eventQueue.add( function() {
+				module.Relational.eventQueue.add( function() {
 					// The `changed` flag can be set in `handleAddition` or `handleRemoval`
 					if ( dit.changed ) {
 						dit.instance.trigger( 'change:' + dit.key, dit.instance, dit.related, options, true );
@@ -1107,7 +1094,7 @@
 
 			// Only trigger 'add' once the newly added model is initialized (so, has its relations set up)
 			var dit = this;
-			!options.silent && Backbone.Relational.eventQueue.add( function() {
+			!options.silent && module.Relational.eventQueue.add( function() {
 				dit.instance.trigger( 'add:' + dit.key, model, dit.related, options );
 			});
 		},
@@ -1126,7 +1113,7 @@
 			}, this );
 
 			var dit = this;
-			!options.silent && Backbone.Relational.eventQueue.add( function() {
+			!options.silent && module.Relational.eventQueue.add( function() {
 				dit.instance.trigger( 'remove:' + dit.key, model, dit.related, options );
 			});
 		},
@@ -1134,7 +1121,7 @@
 		handleReset: function( coll, options ) {
 			var dit = this;
 			options = options ? _.clone( options ) : {};
-			!options.silent && Backbone.Relational.eventQueue.add( function() {
+			!options.silent && module.Relational.eventQueue.add( function() {
 				dit.instance.trigger( 'reset:' + dit.key, dit.related, options );
 			});
 		},
@@ -1173,7 +1160,7 @@
 	 *  - 'remove:<key>' (model, related collection, options)
 	 *  - 'change:<key>' (model, related model or collection, options)
 	 */
-	Backbone.RelationalModel = Backbone.Model.extend({
+	module.RelationalModel = Backbone.Model.extend({
 		relations: null, // Relation descriptions on the prototype
 		_relations: null, // Relation instances
 		_isInitialized: false,
@@ -1213,19 +1200,19 @@
 				});
 			}
 
-			Backbone.Relational.store.processOrphanRelations();
-			Backbone.Relational.store.listenTo( this, 'relational:unregister', Backbone.Relational.store.unregister );
+			module.Relational.store.processOrphanRelations();
+			module.Relational.store.listenTo( this, 'relational:unregister', module.Relational.store.unregister );
 
-			this._queue = new Backbone.BlockingQueue();
+			this._queue = new module.BlockingQueue();
 			this._queue.block();
-			Backbone.Relational.eventQueue.block();
+			module.Relational.eventQueue.block();
 
 			try {
 				Backbone.Model.apply( this, arguments );
 			}
 			finally {
 				// Try to run the global queue holding external events
-				Backbone.Relational.eventQueue.unblock();
+				module.Relational.eventQueue.unblock();
 			}
 		},
 
@@ -1237,12 +1224,12 @@
 				var dit = this,
 					args = arguments;
 
-				if ( !Backbone.Relational.eventQueue.isBlocked() ) {
+				if ( !module.Relational.eventQueue.isLocked() ) {
 					// If we're not in a more complicated nested scenario, fire the change event right away
 					Backbone.Model.prototype.trigger.apply( dit, args );
 				}
 				else {
-					Backbone.Relational.eventQueue.add( function() {
+					module.Relational.eventQueue.add( function() {
 						// Determine if the `change` event is still valid, now that all relations are populated
 						var changed = true;
 						if ( eventName === 'change' ) {
@@ -1283,7 +1270,7 @@
 			}
 			else if ( eventName === 'destroy' ) {
 				Backbone.Model.prototype.trigger.apply( this, arguments );
-				Backbone.Relational.store.unregister( this );
+				module.Relational.store.unregister( this );
 			}
 			else {
 				Backbone.Model.prototype.trigger.apply( this, arguments );
@@ -1301,7 +1288,7 @@
 			this._relations = {};
 
 			_.each( this.relations || [], function( rel ) {
-				Backbone.Relational.store.initializeRelation( this, rel, options );
+				module.Relational.store.initializeRelation( this, rel, options );
 			}, this );
 
 			this._isInitialized = true;
@@ -1379,7 +1366,7 @@
 		 * @return {Array} An array of ids that need to be fetched.
 		 */
 		getIdsToFetch: function( attr, refresh ) {
-			var rel = attr instanceof Backbone.Relation ? attr : this.getRelation( attr ),
+			var rel = attr instanceof module.Relation ? attr : this.getRelation( attr ),
 				ids = rel ? ( rel.keyIds && rel.keyIds.slice( 0 ) ) || ( ( rel.keyId || rel.keyId === 0 ) ? [ rel.keyId ] : [] ) : [];
 
 			// On `refresh`, add the ids for current models in the relation to `idsToFetch`
@@ -1406,7 +1393,7 @@
 		 */
 		getAsync: function( attr, options ) {
 			// Set default `options` for fetch
-			options = _.extend( { add: true, remove: false, refresh: false }, options );
+			options = _.extend( { update: true, remove: false, refresh: false }, options );
 
 			var dit = this,
 				requests = [],
@@ -1493,19 +1480,15 @@
 				}
 			}
 
-			return this.deferArray(requests).then(
+			return $.when.apply( null, requests ).then(
 				function() {
 					return Backbone.Model.prototype.get.call( dit, attr );
 				}
 			);
 		},
 
-		deferArray: function(deferArray) {
-			return Backbone.$.when.apply(null, deferArray);
-		},
-
 		set: function( key, value, options ) {
-			Backbone.Relational.eventQueue.block();
+			module.Relational.eventQueue.block();
 
 			// Duplicate backbone's behavior to allow separate key/value parameters, instead of a single 'attributes' object
 			var attributes,
@@ -1525,7 +1508,7 @@
 					newId = attributes && this.idAttribute in attributes && attributes[ this.idAttribute ];
 
 				// Check if we're not setting a duplicate id before actually calling `set`.
-				Backbone.Relational.store.checkId( this, newId );
+				module.Relational.store.checkId( this, newId );
 
 				result = Backbone.Model.prototype.set.apply( this, arguments );
 
@@ -1535,14 +1518,14 @@
 
 					// Only register models that have an id. A model will be registered when/if it gets an id later on.
 					if ( newId || newId === 0 ) {
-						Backbone.Relational.store.register( this );
+						module.Relational.store.register( this );
 					}
 
 					this.initializeRelations( options );
 				}
 				// The store should know about an `id` update asap
 				else if ( newId && newId !== id ) {
-					Backbone.Relational.store.update( this );
+					module.Relational.store.update( this );
 				}
 
 				if ( attributes ) {
@@ -1551,7 +1534,7 @@
 			}
 			finally {
 				// Try to run the global queue holding external events
-				Backbone.Relational.eventQueue.unblock();
+				module.Relational.eventQueue.unblock();
 			}
 
 			return result;
@@ -1606,10 +1589,10 @@
 
 					// Add ids for 'unfound' models if includeInJSON is equal to (only) the relatedModel's `idAttribute`
 					if ( includeInJSON === rel.relatedModel.prototype.idAttribute ) {
-						if ( rel instanceof Backbone.HasMany ) {
+						if ( rel instanceof module.HasMany ) {
 							value = value.concat( rel.keyIds );
 						}
-						else if ( rel instanceof Backbone.HasOne ) {
+						else if ( rel instanceof module.HasOne ) {
 							value = value || rel.keyId;
 
 							if ( !value && !_.isObject( rel.keyContents ) ) {
@@ -1676,7 +1659,7 @@
 
 			// If this model has 'subModelTypes' itself, remember them in the store
 			if ( this.prototype.hasOwnProperty( 'subModelTypes' ) ) {
-				Backbone.Relational.store.addSubModels( this.prototype.subModelTypes, this );
+				module.Relational.store.addSubModels( this.prototype.subModelTypes, this );
 			}
 			// The 'subModelTypes' property should not be inherited, so reset it.
 			else {
@@ -1701,15 +1684,15 @@
 						 * However, for 3. (which is, to us, indistinguishable from 2.), we do need to attempt
 						 * setting up this relation again later, in case the related model is defined later.
 						 */
-						var relatedModel = Backbone.Relational.store.getObjectByName( rel.relatedModel );
-						preInitialize = relatedModel && ( relatedModel.prototype instanceof Backbone.RelationalModel );
+						var relatedModel = module.Relational.store.getObjectByName( rel.relatedModel );
+						preInitialize = relatedModel && ( relatedModel.prototype instanceof module.RelationalModel );
 					}
 
 					if ( preInitialize ) {
-						Backbone.Relational.store.initializeRelation( null, rel );
+						module.Relational.store.initializeRelation( null, rel );
 					}
 					else if ( _.isString( rel.relatedModel ) ) {
-						Backbone.Relational.store.addOrphanRelation( rel );
+						module.Relational.store.addOrphanRelation( rel );
 					}
 				}
 			}, this );
@@ -1759,7 +1742,6 @@
 					}
 				}
 			}
-
 			return null;
 		},
 
@@ -1776,7 +1758,7 @@
 				var resolvedSubModels = _.keys( this._subModels );
 				var unresolvedSubModels = _.omit( this.prototype.subModelTypes, resolvedSubModels );
 				_.each( unresolvedSubModels, function( subModelTypeName ) {
-					var subModelType = Backbone.Relational.store.getObjectByName( subModelTypeName );
+					var subModelType = module.Relational.store.getObjectByName( subModelTypeName );
 					subModelType && subModelType.initializeModelHierarchy();
 				});
 			}
@@ -1788,7 +1770,7 @@
 				return;
 			}
 			// Try to initialize the _superModel.
-			Backbone.Relational.store.setupSuperModel( this );
+			module.Relational.store.setupSuperModel( this );
 
 			// If a superModel has been found, copy relations from the _superModel if they haven't been inherited automatically
 			// (due to a redefinition of 'relations').
@@ -1819,7 +1801,7 @@
 		 * Find an instance of `this` type in 'Backbone.Relational.store'.
 		 * A new model is created if no matching model is found, `attributes` is an object, and `options.create` is true.
 		 * - If `attributes` is a string or a number, `findOrCreate` will query the `store` and return a model if found.
-		 * - If `attributes` is an object and is found in the store, the model will be updated with `attributes` unless `options.merge` is `false`.
+		 * - If `attributes` is an object and is found in the store, the model will be updated with `attributes` unless `options.update` is `false`.
 		 * @param {Object|String|Number} attributes Either a model's id, or the attributes used to create or update a model.
 		 * @param {Object} [options]
 		 * @param {Boolean} [options.create=true]
@@ -1830,7 +1812,7 @@
 		findOrCreate: function( attributes, options ) {
 			options || ( options = {} );
 			var parsedAttributes = ( _.isObject( attributes ) && options.parse && this.prototype.parse ) ?
-				this.prototype.parse( _.clone( attributes ), options ) : attributes;
+				this.prototype.parse( _.clone( attributes ) ) : attributes;
 
 			// If specified, use a custom `find` function to match up existing models to the given attributes.
 			// Otherwise, try to find an instance of 'this' model type in the store
@@ -1857,7 +1839,7 @@
 		/**
 		 * Find an instance of `this` type in 'Backbone.Relational.store'.
 		 * - If `attributes` is a string or a number, `find` will query the `store` and return a model if found.
-		 * - If `attributes` is an object and is found in the store, the model will be updated with `attributes` unless `options.merge` is `false`.
+		 * - If `attributes` is an object and is found in the store, the model will be updated with `attributes` unless `options.update` is `false`.
 		 * @param {Object|String|Number} attributes Either a model's id, or the attributes used to create or update a model.
 		 * @param {Object} [options]
 		 * @param {Boolean} [options.merge=true]
@@ -1877,10 +1859,10 @@
 		 * @returns {Backbone.RelationalModel}
 		 */
 		findModel: function( attributes ) {
-			return Backbone.Relational.store.find( this, attributes );
+			return module.Relational.store.find( this, attributes );
 		}
 	});
-	_.extend( Backbone.RelationalModel.prototype, Backbone.Semaphore );
+	_.extend( module.RelationalModel.prototype, module.Semaphore );
 
 	/**
 	 * Override Backbone.Collection._prepareModel, so objects will be built using the correct type
@@ -1926,8 +1908,8 @@
 	var set = Backbone.Collection.prototype.__set = Backbone.Collection.prototype.set;
 	Backbone.Collection.prototype.set = function( models, options ) {
 		// Short-circuit if this Collection doesn't hold RelationalModels
-		if ( !( this.model.prototype instanceof Backbone.RelationalModel ) ) {
-			return set.call( this, models, options );
+		if ( !( this.model.prototype instanceof module.RelationalModel ) ) {
+			return set.apply( this, arguments );
 		}
 
 		if ( options && options.parse ) {
@@ -1936,57 +1918,60 @@
 
 		var singular = !_.isArray( models ),
 			newModels = [],
-			toAdd = [],
-			model = null;
+			toAdd = [];
 
 		models = singular ? ( models ? [ models ] : [] ) : _.clone( models );
 
 		//console.debug( 'calling add on coll=%o; model=%o, options=%o', this, models, options );
-		for ( var i = 0; i < models.length; i++ ) {
-			model = models[i];
+		_.each( models, function( model ) {
 			if ( !( model instanceof Backbone.Model ) ) {
 				model = Backbone.Collection.prototype._prepareModel.call( this, model, options );
 			}
+
 			if ( model ) {
 				toAdd.push( model );
+
 				if ( !( this.get( model ) || this.get( model.cid ) ) ) {
 					newModels.push( model );
 				}
 				// If we arrive in `add` while performing a `set` (after a create, so the model gains an `id`),
 				// we may get here before `_onModelEvent` has had the chance to update `_byId`.
-				else if ( model.id !== null && model.id !== undefined ) {
+				else if ( model.id != null ) {
 					this._byId[ model.id ] = model;
 				}
 			}
-		}
+		}, this );
 
 		// Add 'models' in a single batch, so the original add will only be called once (and thus 'sort', etc).
 		// If `parse` was specified, the collection and contained models have been parsed now.
 		toAdd = singular ? ( toAdd.length ? toAdd[ 0 ] : null ) : toAdd;
 		var result = set.call( this, toAdd, _.defaults( { merge: false, parse: false }, options ) );
 
-		for ( i = 0; i < newModels.length; i++ ) {
-			model = newModels[i];
+		_.each( newModels, function( model ) {
 			// Fire a `relational:add` event for any model in `newModels` that has actually been added to the collection.
 			if ( this.get( model ) || this.get( model.cid ) ) {
 				this.trigger( 'relational:add', model, this, options );
 			}
-		}
+		}, this );
 
 		return result;
 	};
 
 	/**
-	 * Override 'Backbone.Collection._removeModels' to trigger 'relational:remove'.
+	 * Override 'Backbone.Collection.remove' to trigger 'relational:remove'.
 	 */
-	var _removeModels = Backbone.Collection.prototype.___removeModels = Backbone.Collection.prototype._removeModels;
-	Backbone.Collection.prototype._removeModels = function( models, options ) {
+	var remove = Backbone.Collection.prototype.__remove = Backbone.Collection.prototype.remove;
+	Backbone.Collection.prototype.remove = function( models, options ) {
 		// Short-circuit if this Collection doesn't hold RelationalModels
-		if ( !( this.model.prototype instanceof Backbone.RelationalModel ) ) {
-			return _removeModels.call( this, models, options );
+		if ( !( this.model.prototype instanceof module.RelationalModel ) ) {
+			return remove.apply( this, arguments );
 		}
 
-		var toRemove = [];
+		var singular = !_.isArray( models ),
+			toRemove = [];
+
+		models = singular ? ( models ? [ models ] : [] ) : _.clone( models );
+		options || ( options = {} );
 
 		//console.debug('calling remove on coll=%o; models=%o, options=%o', this, models, options );
 		_.each( models, function( model ) {
@@ -1994,7 +1979,7 @@
 			model && toRemove.push( model );
 		}, this );
 
-		var result = _removeModels.call( this, toRemove, options );
+		var result = remove.call( this, singular ? ( toRemove.length ? toRemove[ 0 ] : null ) : toRemove, options );
 
 		_.each( toRemove, function( model ) {
 			this.trigger( 'relational:remove', model, this, options );
@@ -2011,7 +1996,7 @@
 		options = _.extend( { merge: true }, options );
 		var result = reset.call( this, models, options );
 
-		if ( this.model.prototype instanceof Backbone.RelationalModel ) {
+		if ( this.model.prototype instanceof module.RelationalModel ) {
 			this.trigger( 'relational:reset', this, options );
 		}
 
@@ -2025,7 +2010,7 @@
 	Backbone.Collection.prototype.sort = function( options ) {
 		var result = sort.call( this, options );
 
-		if ( this.model.prototype instanceof Backbone.RelationalModel ) {
+		if ( this.model.prototype instanceof module.RelationalModel ) {
 			this.trigger( 'relational:reset', this, options );
 		}
 
@@ -2039,7 +2024,7 @@
 	var trigger = Backbone.Collection.prototype.__trigger = Backbone.Collection.prototype.trigger;
 	Backbone.Collection.prototype.trigger = function( eventName ) {
 		// Short-circuit if this Collection doesn't hold RelationalModels
-		if ( !( this.model.prototype instanceof Backbone.RelationalModel ) ) {
+		if ( !( this.model.prototype instanceof module.RelationalModel ) ) {
 			return trigger.apply( this, arguments );
 		}
 
@@ -2054,7 +2039,7 @@
 				args[ 3 ] = _.clone( args[ 3 ] );
 			}
 
-			Backbone.Relational.eventQueue.add( function() {
+			module.Relational.eventQueue.add( function() {
 				trigger.apply( dit, args );
 			});
 		}
@@ -2066,13 +2051,13 @@
 	};
 
 	// Override .extend() to automatically call .setup()
-	Backbone.RelationalModel.extend = function( protoProps, classProps ) {
-		var child = Backbone.Model.extend.call( this, protoProps, classProps );
+	module.RelationalModel.extend = function( protoProps, classProps ) {
+		var child = Backbone.Model.extend.apply( this, arguments );
 
 		child.setup( this );
 
 		return child;
 	};
-
-	return Backbone;
+	_.extend(Backbone, module);
+	return module;
 }));

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -1460,7 +1460,7 @@
 								_.each( createdModels, function( model ) {
 									model.trigger( 'destroy', model, model.collection, options );
 								});
-								
+
 								options.error && options.error.apply( models, arguments );
 							},
 							url: setUrl
@@ -1499,7 +1499,7 @@
 				}
 			);
 		},
-		
+
 		deferArray: function(deferArray) {
 			return Backbone.$.when.apply(null, deferArray);
 		},
@@ -2073,4 +2073,6 @@
 
 		return child;
 	};
+
+	return Backbone;
 }));


### PR DESCRIPTION
In order to use ES6 module syntax, we need to return the extended Backbone object.

Then, we'll be able to import this extended Backbone object in other projects:
`import Relational from 'Backbone-relational'`