### PR TITLE
Update exports for es6

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -9,7 +9,7 @@
  *
  * Example:
  *
-	Zoo = Backbone.RelationalModel.extend({
+	Zoo = Backbone.Relational.Model.extend({
 		relations: [ {
 			type: Backbone.HasMany,
 			key: 'animals',
@@ -26,7 +26,7 @@
 		}
 	});
 
-	Animal = Backbone.RelationalModel.extend({
+	Animal = Backbone.Relational.Model.extend({
 		toString: function() {
 			return this.get( 'species' );
 		}
@@ -45,30 +45,36 @@
 		monkey = zoo.get( 'animals' ).first(),
 		sameZoo = lion.get( 'livesIn' );
  */
-( function( root, factory ) {
+( function( factory ) {
+	// Establish the root object, `window` (`self`) in the browser, or `global` on the server.
+	// We use `self` instead of `window` for `WebWorker` support.
+	var root = (typeof self == 'object' && self.self == self && self) ||
+		(typeof global == 'object' && global.global == global && global);
+
 	// Set up Backbone-relational for the environment. Start with AMD.
 	if ( typeof define === 'function' && define.amd ) {
-		define( [ 'exports', 'backbone', 'underscore' ], factory );
+		define( [ 'exports', 'backbone', 'underscore' ], function(exports, Backbone, _){
+			factory(exports, Backbone, _, root);
+		});
 	}
 	// Next for Node.js or CommonJS.
 	else if ( typeof exports !== 'undefined' ) {
-		factory( exports, require( 'backbone' ), require( 'underscore' ) );
+		factory( exports, require( 'backbone' ), require( 'underscore' ), root );
 	}
 	// Finally, as a browser global. Use `root` here as it references `window`.
 	else {
-		factory( root, root.Backbone, root._ );
+		root.Backbone.Relational = factory( {} , root.Backbone, root._, root );
 	}
-}( this, function( exports, Backbone, _ ) {
+}( function( module, Backbone, _, root ) {
 	"use strict";
 
-	Backbone.Relational = {
-		showWarnings: true
-	};
+	module.Collection = Backbone.Collection.extend();
+	module.showWarnings = true;
 
 	/**
 	 * Semaphore mixin; can be used as both binary and counting.
 	 **/
-	Backbone.Semaphore = {
+	module.Semaphore = {
 		_permitsAvailable: null,
 		_permitsUsed: 0,
 
@@ -107,10 +113,10 @@
 	 * and processes them when unblocked (via 'unblock').
 	 * Process can also be called manually (via 'process').
 	 */
-	Backbone.BlockingQueue = function() {
+	module.BlockingQueue = function() {
 		this._queue = [];
 	};
-	_.extend( Backbone.BlockingQueue.prototype, Backbone.Semaphore, {
+	_.extend( module.BlockingQueue.prototype, module.Semaphore, {
 		_queue: null,
 
 		add: function( func ) {
@@ -157,35 +163,35 @@
 	});
 	/**
 	 * Global event queue. Accumulates external events ('add:<key>', 'remove:<key>' and 'change:<key>')
-	 * until the top-level object is fully initialized (see 'Backbone.RelationalModel').
+	 * until the top-level object is fully initialized (see 'Backbone.Relational.Model').
 	 */
-	Backbone.Relational.eventQueue = new Backbone.BlockingQueue();
+	module.eventQueue = new module.BlockingQueue();
 
 	/**
-	 * Backbone.Store keeps track of all created (and destruction of) Backbone.RelationalModel.
+	 * Backbone.Store keeps track of all created (and destruction of) Backbone.Relational.Model.
 	 * Handles lookup for relations.
 	 */
-	Backbone.Store = function() {
+	module.Store = function() {
 		this._collections = [];
 		this._reverseRelations = [];
 		this._orphanRelations = [];
 		this._subModels = [];
-		this._modelScopes = [ exports ];
+		this._modelScopes = [ root ];
 	};
-	_.extend( Backbone.Store.prototype, Backbone.Events, {
+	_.extend( module.Store.prototype, Backbone.Events, {
 		/**
 		 * Create a new `Relation`.
-		 * @param {Backbone.RelationalModel} [model]
+		 * @param {Backbone.Relational.Model} [model]
 		 * @param {Object} relation
 		 * @param {Object} [options]
 		 */
 		initializeRelation: function( model, relation, options ) {
-			var type = !_.isString( relation.type ) ? relation.type : Backbone[ relation.type ] || this.getObjectByName( relation.type );
-			if ( type && type.prototype instanceof Backbone.Relation ) {
+			var type = !_.isString( relation.type ) ? relation.type : module[ relation.type ] || this.getObjectByName( relation.type );
+			if ( type && type.prototype instanceof module.Relation ) {
 				var rel = new type( model, relation, options ); // Also pushes the new Relation into `model._relations`
 			}
 			else {
-				Backbone.Relational.showWarnings && typeof console !== 'undefined' && console.warn( 'Relation=%o; missing or invalid relation type!', relation );
+				module.showWarnings && typeof console !== 'undefined' && console.warn( 'Relation=%o; missing or invalid relation type!', relation );
 			}
 		},
 
@@ -209,8 +215,8 @@
 		 * Add a set of subModelTypes to the store, that can be used to resolve the '_superModel'
 		 * for a model later in 'setupSuperModel'.
 		 *
-		 * @param {Backbone.RelationalModel} subModelTypes
-		 * @param {Backbone.RelationalModel} superModelType
+		 * @param {Backbone.Relational.Model} subModelTypes
+		 * @param {Backbone.Relational.Model} superModelType
 		 */
 		addSubModels: function( subModelTypes, superModelType ) {
 			this._subModels.push({
@@ -223,7 +229,7 @@
 		 * Check if the given modelType is registered as another model's subModel. If so, add it to the super model's
 		 * '_subModels', and set the modelType's '_superModel', '_subModelTypeName', and '_subModelTypeAttribute'.
 		 *
-		 * @param {Backbone.RelationalModel} modelType
+		 * @param {Backbone.Relational.Model} modelType
 		 */
 		setupSuperModel: function( modelType ) {
 			_.find( this._subModels, function( subModelDef ) {
@@ -248,7 +254,7 @@
 		 * Add a reverse relation. Is added to the 'relations' property on model's prototype, and to
 		 * existing instances of 'model' in the store as well.
 		 * @param {Object} relation
-		 * @param {Backbone.RelationalModel} relation.model
+		 * @param {Backbone.Relational.Model} relation.model
 		 * @param {String} relation.type
 		 * @param {String} relation.key
 		 * @param {String|Object} relation.relatedModel
@@ -290,7 +296,7 @@
 		processOrphanRelations: function() {
 			// Make sure to operate on a copy since we're removing while iterating
 			_.each( this._orphanRelations.slice( 0 ), function( rel ) {
-				var relatedModel = Backbone.Relational.store.getObjectByName( rel.relatedModel );
+				var relatedModel = module.store.getObjectByName( rel.relatedModel );
 				if ( relatedModel ) {
 					this.initializeRelation( null, rel );
 					this._orphanRelations = _.without( this._orphanRelations, rel );
@@ -300,7 +306,7 @@
 
 		/**
 		 *
-		 * @param {Backbone.RelationalModel.constructor} type
+		 * @param {Backbone.Relational.Model.constructor} type
 		 * @param {Object} relation
 		 * @private
 		 */
@@ -332,12 +338,12 @@
 
 		/**
 		 * Find the Store's collection for a certain type of model.
-		 * @param {Backbone.RelationalModel} type
+		 * @param {Backbone.Relational.Model} type
 		 * @param {Boolean} [create=true] Should a collection be created if none is found?
-		 * @return {Backbone.Collection} A collection if found (or applicable for 'model'), or null
+		 * @return {module.Collection} A collection if found (or applicable for 'model'), or null
 		 */
 		getCollection: function( type, create ) {
-			if ( type instanceof Backbone.RelationalModel ) {
+			if ( type instanceof module.Model ) {
 				type = type.constructor;
 			}
 
@@ -383,13 +389,13 @@
 			var coll;
 
 			// If 'type' is an instance, take its constructor
-			if ( type instanceof Backbone.RelationalModel ) {
+			if ( type instanceof module.Model ) {
 				type = type.constructor;
 			}
 
-			// Type should inherit from Backbone.RelationalModel.
-			if ( type.prototype instanceof Backbone.RelationalModel ) {
-				coll = new Backbone.Collection();
+			// Type should inherit from Backbone.Relational.Model.
+			if ( type.prototype instanceof module.Model ) {
+				coll = new module.Collection();
 				coll.model = type;
 
 				this._collections.push( coll );
@@ -401,14 +407,14 @@
 		/**
 		 * Find the attribute that is to be used as the `id` on a given object
 		 * @param type
-		 * @param {String|Number|Object|Backbone.RelationalModel} item
+		 * @param {String|Number|Object|Backbone.Relational.Model} item
 		 * @return {String|Number}
 		 */
 		resolveIdForItem: function( type, item ) {
 			var id = _.isString( item ) || _.isNumber( item ) ? item : null;
 
 			if ( id === null ) {
-				if ( item instanceof Backbone.RelationalModel ) {
+				if ( item instanceof module.Model ) {
 					id = item.id;
 				}
 				else if ( _.isObject( item ) ) {
@@ -427,7 +433,7 @@
 		/**
 		 * Find a specific model of a certain `type` in the store
 		 * @param type
-		 * @param {String|Number|Object|Backbone.RelationalModel} item
+		 * @param {String|Number|Object|Backbone.Relational.Model} item
 		 */
 		find: function( type, item ) {
 			var id = this.resolveIdForItem( type, item ),
@@ -448,7 +454,7 @@
 
 		/**
 		 * Add a 'model' to its appropriate collection. Retain the original contents of 'model.collection'.
-		 * @param {Backbone.RelationalModel} model
+		 * @param {Backbone.Relational.Model} model
 		 */
 		register: function( model ) {
 			var coll = this.getCollection( model );
@@ -470,17 +476,17 @@
 				duplicate = coll && coll.get( id );
 
 			if ( duplicate && model !== duplicate ) {
-				if ( Backbone.Relational.showWarnings && typeof console !== 'undefined' ) {
+				if ( module.showWarnings && typeof console !== 'undefined' ) {
 					console.warn( 'Duplicate id! Old RelationalModel=%o, new RelationalModel=%o', duplicate, model );
 				}
 
-				throw new Error( "Cannot instantiate more than one Backbone.RelationalModel with the same id per type!" );
+				throw new Error( "Cannot instantiate more than one Backbone.Relational.Model with the same id per type!" );
 			}
 		},
 
 		/**
 		 * Explicitly update a model's id in its store collection
-		 * @param {Backbone.RelationalModel} model
+		 * @param {Backbone.Relational.Model} model
 		 */
 		update: function( model ) {
 			var coll = this.getCollection( model );
@@ -499,7 +505,7 @@
 
 		/**
 		 * Unregister from the store: a specific model, a collection, or a model type.
-		 * @param {Backbone.RelationalModel|Backbone.RelationalModel.constructor|Backbone.Collection} type
+		 * @param {Backbone.Relational.Model|Backbone.Relational.Model.constructor|module.Collection} type
 		 */
 		unregister: function( type ) {
 			var coll,
@@ -509,7 +515,7 @@
 				coll = this.getCollection( type );
 				models = [ type ];
 			}
-			else if ( type instanceof Backbone.Collection ) {
+			else if ( type instanceof module.Collection ) {
 				coll = this.getCollection( type.model );
 				models = _.clone( type.models );
 			}
@@ -555,20 +561,20 @@
 
 			this._collections = [];
 			this._subModels = [];
-			this._modelScopes = [ exports ];
+			this._modelScopes = [ root ];
 		}
 	});
-	Backbone.Relational.store = new Backbone.Store();
+	module.store = new module.Store();
 
 	/**
 	 * The main Relation class, from which 'HasOne' and 'HasMany' inherit. Internally, 'relational:<key>' events
 	 * are used to regulate addition and removal of models from relations.
 	 *
-	 * @param {Backbone.RelationalModel} [instance] Model that this relation is created for. If no model is supplied,
+	 * @param {Backbone.Relational.Model} [instance] Model that this relation is created for. If no model is supplied,
 	 *      Relation just tries to instantiate it's `reverseRelation` if specified, and bails out after that.
 	 * @param {Object} options
 	 * @param {string} options.key
-	 * @param {Backbone.RelationalModel.constructor} options.relatedModel
+	 * @param {Backbone.Relational.Model.constructor} options.relatedModel
 	 * @param {Boolean|String} [options.includeInJSON=true] Serialize the given attribute for related model(s)' in toJSON, or just their ids.
 	 * @param {Boolean} [options.createModels=true] Create objects from the contents of keys if the object is not found in Backbone.store.
 	 * @param {Object} [options.reverseRelation] Specify a bi-directional relation. If provided, Relation will reciprocate
@@ -576,15 +582,15 @@
 	 *    {Backbone.Relation|String} type ('HasOne' or 'HasMany').
 	 * @param {Object} opts
 	 */
-	Backbone.Relation = function( instance, options, opts ) {
+	module.Relation = function( instance, options, opts ) {
 		this.instance = instance;
 		// Make sure 'options' is sane, and fill with defaults from subclasses and this object's prototype
 		options = _.isObject( options ) ? options : {};
 		this.reverseRelation = _.defaults( options.reverseRelation || {}, this.options.reverseRelation );
-		this.options = _.defaults( options, this.options, Backbone.Relation.prototype.options );
+		this.options = _.defaults( options, this.options, module.Relation.prototype.options );
 
 		this.reverseRelation.type = !_.isString( this.reverseRelation.type ) ? this.reverseRelation.type :
-			Backbone[ this.reverseRelation.type ] || Backbone.Relational.store.getObjectByName( this.reverseRelation.type );
+			module[ this.reverseRelation.type ] || module.store.getObjectByName( this.reverseRelation.type );
 
 		this.key = this.options.key;
 		this.keySource = this.options.keySource || this.key;
@@ -594,19 +600,16 @@
 
 		this.relatedModel = this.options.relatedModel;
 
-		// No 'relatedModel' is interpreted as self-referential
-		if ( _.isUndefined( this.relatedModel ) ) {
+		if(_.isUndefined(this.relatedModel)){
 			this.relatedModel = this.model;
 		}
 
-		// Otherwise, try to resolve the given value to an object
-		if ( _.isFunction( this.relatedModel ) && !( this.relatedModel.prototype instanceof Backbone.RelationalModel ) ) {
+		if ( _.isFunction( this.relatedModel ) && !( this.relatedModel.prototype instanceof module.Model ) ) {
 			this.relatedModel = _.result( this, 'relatedModel' );
 		}
 		if ( _.isString( this.relatedModel ) ) {
-			this.relatedModel = Backbone.Relational.store.getObjectByName( this.relatedModel );
+			this.relatedModel = module.store.getObjectByName( this.relatedModel );
 		}
-
 
 		if ( !this.checkPreconditions() ) {
 			return;
@@ -614,7 +617,7 @@
 
 		// Add the reverse relation on 'relatedModel' to the store's reverseRelations
 		if ( !this.options.isAutoRelation && this.reverseRelation.type && this.reverseRelation.key ) {
-			Backbone.Relational.store.addReverseRelation( _.defaults( {
+			module.store.addReverseRelation( _.defaults( {
 					isAutoRelation: true,
 					model: this.relatedModel,
 					relatedModel: this.model,
@@ -631,7 +634,7 @@
 			}
 
 			this.setKeyContents( this.instance.get( contentKey ) );
-			this.relatedCollection = Backbone.Relational.store.getCollection( this.relatedModel );
+			this.relatedCollection = module.store.getCollection( this.relatedModel );
 
 			// Explicitly clear 'keySource', to prevent a leaky abstraction if 'keySource' differs from 'key'.
 			if ( this.keySource !== this.key ) {
@@ -654,9 +657,9 @@
 		}
 	};
 	// Fix inheritance :\
-	Backbone.Relation.extend = Backbone.Model.extend;
+	module.Relation.extend = Backbone.Model.extend;
 	// Set up all inheritable **Backbone.Relation** properties and methods.
-	_.extend( Backbone.Relation.prototype, Backbone.Events, Backbone.Semaphore, {
+	_.extend( module.Relation.prototype, Backbone.Events, module.Semaphore, {
 		options: {
 			createModels: true,
 			includeInJSON: true,
@@ -682,24 +685,24 @@
 				k = this.key,
 				m = this.model,
 				rm = this.relatedModel,
-				warn = Backbone.Relational.showWarnings && typeof console !== 'undefined';
+				warn = module.showWarnings && typeof console !== 'undefined';
 
 			if ( !m || !k || !rm ) {
 				warn && console.warn( 'Relation=%o: missing model, key or relatedModel (%o, %o, %o).', this, m, k, rm );
 				return false;
 			}
-			// Check if the type in 'model' inherits from Backbone.RelationalModel
-			if ( !( m.prototype instanceof Backbone.RelationalModel ) ) {
-				warn && console.warn( 'Relation=%o: model does not inherit from Backbone.RelationalModel (%o).', this, i );
+			// Check if the type in 'model' inherits from Backbone.Relational.Model
+			if ( !( m.prototype instanceof module.Model ) ) {
+				warn && console.warn( 'Relation=%o: model does not inherit from Backbone.Relational.Model (%o).', this, i );
 				return false;
 			}
-			// Check if the type in 'relatedModel' inherits from Backbone.RelationalModel
-			if ( !( rm.prototype instanceof Backbone.RelationalModel ) ) {
-				warn && console.warn( 'Relation=%o: relatedModel does not inherit from Backbone.RelationalModel (%o).', this, rm );
+			// Check if the type in 'relatedModel' inherits from Backbone.Relational.Model
+			if ( !( rm.prototype instanceof module.Model ) ) {
+				warn && console.warn( 'Relation=%o: relatedModel does not inherit from Backbone.Relational.Model (%o).', this, rm );
 				return false;
 			}
 			// Check if this is not a HasMany, and the reverse relation is HasMany as well
-			if ( this instanceof Backbone.HasMany && this.reverseRelation.type === Backbone.HasMany ) {
+			if ( this instanceof module.HasMany && this.reverseRelation.type === module.HasMany ) {
 				warn && console.warn( 'Relation=%o: relation is a HasMany, and the reverseRelation is HasMany as well.', this );
 				return false;
 			}
@@ -721,7 +724,7 @@
 
 		/**
 		 * Set the related model(s) for this relation
-		 * @param {Backbone.Model|Backbone.Collection} related
+		 * @param {Backbone.Model|module.Collection} related
 		 */
 		setRelated: function( related ) {
 			this.related = related;
@@ -741,13 +744,13 @@
 
 		/**
 		 * Get the reverse relations (pointing back to 'this.key' on 'this.instance') for the currently related model(s).
-		 * @param {Backbone.RelationalModel} [model] Get the reverse relations for a specific model.
+		 * @param {Backbone.Relational.Model} [model] Get the reverse relations for a specific model.
 		 *    If not specified, 'this.related' is used.
 		 * @return {Backbone.Relation[]}
 		 */
 		getReverseRelations: function( model ) {
 			var reverseRelations = [];
-			// Iterate over 'model', 'this.related.models' (if this.related is a Backbone.Collection), or wrap 'this.related' in an array.
+			// Iterate over 'model', 'this.related.models' (if this.related is a module.Collection), or wrap 'this.related' in an array.
 			var models = !_.isUndefined( model ) ? [ model ] : this.related && ( this.related.models || [ this.related ] ),
 				relations = null,
 				relation = null;
@@ -757,6 +760,7 @@
 
 				for( var j = 0; j < relations.length; j++ ) {
 					relation = relations[ j ];
+
 
 					if ( this._isReverseRelation( relation ) ) {
 						reverseRelations.push( relation );
@@ -774,10 +778,10 @@
 		destroy: function() {
 			this.stopListening();
 
-			if ( this instanceof Backbone.HasOne ) {
+			if ( this instanceof module.HasOne ) {
 				this.setRelated( null );
 			}
-			else if ( this instanceof Backbone.HasMany ) {
+			else if ( this instanceof module.HasMany ) {
 				this.setRelated( this._prepareCollection() );
 			}
 
@@ -787,7 +791,7 @@
 		}
 	});
 
-	Backbone.HasOne = Backbone.Relation.extend({
+	module.HasOne = module.Relation.extend({
 		options: {
 			reverseRelation: { type: 'HasMany' }
 		},
@@ -836,7 +840,7 @@
 		 */
 		setKeyContents: function( keyContents ) {
 			this.keyContents = keyContents;
-			this.keyId = Backbone.Relational.store.resolveIdForItem( this.relatedModel, this.keyContents );
+			this.keyId = module.store.resolveIdForItem( this.relatedModel, this.keyContents );
 		},
 
 		/**
@@ -881,7 +885,7 @@
 			if ( !options.silent && this.related !== oldRelated ) {
 				var dit = this;
 				this.changed = true;
-				Backbone.Relational.eventQueue.add( function() {
+				module.eventQueue.add( function() {
 					dit.instance.trigger( 'change:' + dit.key, dit.instance, dit.related, options, true );
 					dit.changed = false;
 				});
@@ -925,12 +929,12 @@
 		}
 	});
 
-	Backbone.HasMany = Backbone.Relation.extend({
+	module.HasMany = module.Relation.extend({
 		collectionType: null,
 
 		options: {
 			reverseRelation: { type: 'HasOne' },
-			collectionType: Backbone.Collection,
+			collectionType: module.Collection,
 			collectionKey: true,
 			collectionOptions: {}
 		},
@@ -940,14 +944,14 @@
 
 			// Handle a custom 'collectionType'
 			this.collectionType = this.options.collectionType;
-			if ( _.isFunction( this.collectionType ) && this.collectionType !== Backbone.Collection && !( this.collectionType.prototype instanceof Backbone.Collection ) ) {
+			if ( _.isFunction( this.collectionType ) && this.collectionType !== module.Collection && !( this.collectionType.prototype instanceof module.Collection ) ) {
 				this.collectionType = _.result( this, 'collectionType' );
 			}
 			if ( _.isString( this.collectionType ) ) {
-				this.collectionType = Backbone.Relational.store.getObjectByName( this.collectionType );
+				this.collectionType = module.store.getObjectByName( this.collectionType );
 			}
-			if ( this.collectionType !== Backbone.Collection && !( this.collectionType.prototype instanceof Backbone.Collection ) ) {
-				throw new Error( '`collectionType` must inherit from Backbone.Collection' );
+			if ( this.collectionType !== module.Collection && !( this.collectionType.prototype instanceof module.Collection ) ) {
+				throw new Error( '`collectionType` must inherit from module.Collection' );
 			}
 
 			var related = this.findRelated( opts );
@@ -957,15 +961,15 @@
 		/**
 		 * Bind events and setup collectionKeys for a collection that is to be used as the backing store for a HasMany.
 		 * If no 'collection' is supplied, a new collection will be created of the specified 'collectionType' option.
-		 * @param {Backbone.Collection} [collection]
-		 * @return {Backbone.Collection}
+		 * @param {module.Collection} [collection]
+		 * @return {module.Collection}
 		 */
 		_prepareCollection: function( collection ) {
 			if ( this.related ) {
 				this.stopListening( this.related );
 			}
 
-			if ( !collection || !( collection instanceof Backbone.Collection ) ) {
+			if ( !collection || !( collection instanceof module.Collection ) ) {
 				var options = _.isFunction( this.options.collectionOptions ) ?
 					this.options.collectionOptions( this.instance ) : this.options.collectionOptions;
 
@@ -978,7 +982,7 @@
 				var key = this.options.collectionKey === true ? this.options.reverseRelation.key : this.options.collectionKey;
 
 				if ( collection[ key ] && collection[ key ] !== this.instance ) {
-					if ( Backbone.Relational.showWarnings && typeof console !== 'undefined' ) {
+					if ( module.showWarnings && typeof console !== 'undefined' ) {
 						console.warn( 'Relation=%o; collectionKey=%s already exists on collection=%o', this, key, this.options.collectionKey );
 					}
 				}
@@ -997,20 +1001,20 @@
 		/**
 		 * Find related Models.
 		 * @param {Object} [options]
-		 * @return {Backbone.Collection}
+		 * @return {module.Collection}
 		 */
 		findRelated: function( options ) {
 			var related = null;
 
 			options = _.defaults( { parse: this.options.parse }, options );
 
-			// Replace 'this.related' by 'this.keyContents' if it is a Backbone.Collection
-			if ( this.keyContents instanceof Backbone.Collection ) {
+			// Replace 'this.related' by 'this.keyContents' if it is a module.Collection
+			if ( this.keyContents instanceof module.Collection ) {
 				this._prepareCollection( this.keyContents );
 				related = this.keyContents;
 			}
 			// Otherwise, 'this.keyContents' should be an array of related object ids.
-			// Re-use the current 'this.related' if it is a Backbone.Collection; otherwise, create a new collection.
+			// Re-use the current 'this.related' if it is a module.Collection; otherwise, create a new collection.
 			else {
 				var toAdd = [];
 
@@ -1029,7 +1033,7 @@
 					model && toAdd.push( model );
 				}, this );
 
-				if ( this.related instanceof Backbone.Collection ) {
+				if ( this.related instanceof module.Collection ) {
 					related = this.related;
 				}
 				else {
@@ -1049,10 +1053,10 @@
 
 		/**
 		 * Normalize and reduce `keyContents` to a list of `ids`, for easier comparison
-		 * @param {String|Number|String[]|Number[]|Backbone.Collection} keyContents
+		 * @param {String|Number|String[]|Number[]|module.Collection} keyContents
 		 */
 		setKeyContents: function( keyContents ) {
-			this.keyContents = keyContents instanceof Backbone.Collection ? keyContents : null;
+			this.keyContents = keyContents instanceof module.Collection ? keyContents : null;
 			this.keyIds = [];
 
 			if ( !this.keyContents && ( keyContents || keyContents === 0 ) ) { // since 0 can be a valid `id` as well
@@ -1060,7 +1064,7 @@
 				this.keyContents = _.isArray( keyContents ) ? keyContents : [ keyContents ];
 
 				_.each( this.keyContents, function( item ) {
-					var itemId = Backbone.Relational.store.resolveIdForItem( this.relatedModel, item );
+					var itemId = module.store.resolveIdForItem( this.relatedModel, item );
 					if ( itemId || itemId === 0 ) {
 						this.keyIds.push( itemId );
 					}
@@ -1082,7 +1086,7 @@
 
 			if ( !options.silent ) {
 				var dit = this;
-				Backbone.Relational.eventQueue.add( function() {
+				module.eventQueue.add( function() {
 					// The `changed` flag can be set in `handleAddition` or `handleRemoval`
 					if ( dit.changed ) {
 						dit.instance.trigger( 'change:' + dit.key, dit.instance, dit.related, options, true );
@@ -1107,7 +1111,7 @@
 
 			// Only trigger 'add' once the newly added model is initialized (so, has its relations set up)
 			var dit = this;
-			!options.silent && Backbone.Relational.eventQueue.add( function() {
+			!options.silent && module.eventQueue.add( function() {
 				dit.instance.trigger( 'add:' + dit.key, model, dit.related, options );
 			});
 		},
@@ -1126,7 +1130,7 @@
 			}, this );
 
 			var dit = this;
-			!options.silent && Backbone.Relational.eventQueue.add( function() {
+			!options.silent && module.eventQueue.add( function() {
 				dit.instance.trigger( 'remove:' + dit.key, model, dit.related, options );
 			});
 		},
@@ -1134,7 +1138,7 @@
 		handleReset: function( coll, options ) {
 			var dit = this;
 			options = options ? _.clone( options ) : {};
-			!options.silent && Backbone.Relational.eventQueue.add( function() {
+			!options.silent && module.eventQueue.add( function() {
 				dit.instance.trigger( 'reset:' + dit.key, dit.related, options );
 			});
 		},
@@ -1173,7 +1177,7 @@
 	 *  - 'remove:<key>' (model, related collection, options)
 	 *  - 'change:<key>' (model, related model or collection, options)
 	 */
-	Backbone.RelationalModel = Backbone.Model.extend({
+	module.Model = Backbone.Model.extend({
 		relations: null, // Relation descriptions on the prototype
 		_relations: null, // Relation instances
 		_isInitialized: false,
@@ -1213,19 +1217,19 @@
 				});
 			}
 
-			Backbone.Relational.store.processOrphanRelations();
-			Backbone.Relational.store.listenTo( this, 'relational:unregister', Backbone.Relational.store.unregister );
+			module.store.processOrphanRelations();
+			module.store.listenTo( this, 'relational:unregister', module.store.unregister );
 
-			this._queue = new Backbone.BlockingQueue();
+			this._queue = new module.BlockingQueue();
 			this._queue.block();
-			Backbone.Relational.eventQueue.block();
+			module.eventQueue.block();
 
 			try {
 				Backbone.Model.apply( this, arguments );
 			}
 			finally {
 				// Try to run the global queue holding external events
-				Backbone.Relational.eventQueue.unblock();
+				module.eventQueue.unblock();
 			}
 		},
 
@@ -1237,12 +1241,12 @@
 				var dit = this,
 					args = arguments;
 
-				if ( !Backbone.Relational.eventQueue.isBlocked() ) {
+				if ( !module.eventQueue.isLocked() ) {
 					// If we're not in a more complicated nested scenario, fire the change event right away
 					Backbone.Model.prototype.trigger.apply( dit, args );
 				}
 				else {
-					Backbone.Relational.eventQueue.add( function() {
+					module.eventQueue.add( function() {
 						// Determine if the `change` event is still valid, now that all relations are populated
 						var changed = true;
 						if ( eventName === 'change' ) {
@@ -1283,7 +1287,7 @@
 			}
 			else if ( eventName === 'destroy' ) {
 				Backbone.Model.prototype.trigger.apply( this, arguments );
-				Backbone.Relational.store.unregister( this );
+				module.store.unregister( this );
 			}
 			else {
 				Backbone.Model.prototype.trigger.apply( this, arguments );
@@ -1301,7 +1305,7 @@
 			this._relations = {};
 
 			_.each( this.relations || [], function( rel ) {
-				Backbone.Relational.store.initializeRelation( this, rel, options );
+				module.store.initializeRelation( this, rel, options );
 			}, this );
 
 			this._isInitialized = true;
@@ -1379,7 +1383,7 @@
 		 * @return {Array} An array of ids that need to be fetched.
 		 */
 		getIdsToFetch: function( attr, refresh ) {
-			var rel = attr instanceof Backbone.Relation ? attr : this.getRelation( attr ),
+			var rel = attr instanceof module.Relation ? attr : this.getRelation( attr ),
 				ids = rel ? ( rel.keyIds && rel.keyIds.slice( 0 ) ) || ( ( rel.keyId || rel.keyId === 0 ) ? [ rel.keyId ] : [] ) : [];
 
 			// On `refresh`, add the ids for current models in the relation to `idsToFetch`
@@ -1412,7 +1416,7 @@
 				requests = [],
 				rel = this.getRelation( attr ),
 				idsToFetch = rel && this.getIdsToFetch( rel, options.refresh ),
-				coll = rel.related instanceof Backbone.Collection ? rel.related : rel.relatedCollection;
+				coll = rel.related instanceof module.Collection ? rel.related : rel.relatedCollection;
 
 			if ( idsToFetch && idsToFetch.length ) {
 				var models = [],
@@ -1435,10 +1439,10 @@
 					};
 
 				// Try if the 'collection' can provide a url to fetch a set of models in one request.
-				// This assumes that when 'Backbone.Collection.url' is a function, it can handle building of set urls.
+				// This assumes that when 'module.Collection.url' is a function, it can handle building of set urls.
 				// To make sure it can, test if the url we got by supplying a list of models to fetch is different from
 				// the one supplied for the default fetch action (without args to 'url').
-				if ( coll instanceof Backbone.Collection && _.isFunction( coll.url ) ) {
+				if ( coll instanceof module.Collection && _.isFunction( coll.url ) ) {
 					var defaultUrl = coll.url();
 					setUrl = coll.url( idsToFetch );
 
@@ -1460,7 +1464,7 @@
 								_.each( createdModels, function( model ) {
 									model.trigger( 'destroy', model, model.collection, options );
 								});
-								
+
 								options.error && options.error.apply( models, arguments );
 							},
 							url: setUrl
@@ -1499,13 +1503,13 @@
 				}
 			);
 		},
-		
+
 		deferArray: function(deferArray) {
 			return Backbone.$.when.apply(null, deferArray);
 		},
 
 		set: function( key, value, options ) {
-			Backbone.Relational.eventQueue.block();
+			module.eventQueue.block();
 
 			// Duplicate backbone's behavior to allow separate key/value parameters, instead of a single 'attributes' object
 			var attributes,
@@ -1525,7 +1529,7 @@
 					newId = attributes && this.idAttribute in attributes && attributes[ this.idAttribute ];
 
 				// Check if we're not setting a duplicate id before actually calling `set`.
-				Backbone.Relational.store.checkId( this, newId );
+				module.store.checkId( this, newId );
 
 				result = Backbone.Model.prototype.set.apply( this, arguments );
 
@@ -1535,14 +1539,14 @@
 
 					// Only register models that have an id. A model will be registered when/if it gets an id later on.
 					if ( newId || newId === 0 ) {
-						Backbone.Relational.store.register( this );
+						module.store.register( this );
 					}
 
 					this.initializeRelations( options );
 				}
 				// The store should know about an `id` update asap
 				else if ( newId && newId !== id ) {
-					Backbone.Relational.store.update( this );
+					module.store.update( this );
 				}
 
 				if ( attributes ) {
@@ -1551,7 +1555,7 @@
 			}
 			finally {
 				// Try to run the global queue holding external events
-				Backbone.Relational.eventQueue.unblock();
+				module.eventQueue.unblock();
 			}
 
 			return result;
@@ -1597,7 +1601,7 @@
 					}
 				}
 				else if ( _.isString( includeInJSON ) ) {
-					if ( related instanceof Backbone.Collection ) {
+					if ( related instanceof module.Collection ) {
 						value = related.pluck( includeInJSON );
 					}
 					else if ( related instanceof Backbone.Model ) {
@@ -1606,10 +1610,10 @@
 
 					// Add ids for 'unfound' models if includeInJSON is equal to (only) the relatedModel's `idAttribute`
 					if ( includeInJSON === rel.relatedModel.prototype.idAttribute ) {
-						if ( rel instanceof Backbone.HasMany ) {
+						if ( rel instanceof module.HasMany ) {
 							value = value.concat( rel.keyIds );
 						}
-						else if ( rel instanceof Backbone.HasOne ) {
+						else if ( rel instanceof module.HasOne ) {
 							value = value || rel.keyId;
 
 							if ( !value && !_.isObject( rel.keyContents ) ) {
@@ -1619,7 +1623,7 @@
 					}
 				}
 				else if ( _.isArray( includeInJSON ) ) {
-					if ( related instanceof Backbone.Collection ) {
+					if ( related instanceof module.Collection ) {
 						value = [];
 						related.each( function( model ) {
 							var curJson = {};
@@ -1664,7 +1668,7 @@
 		/**
 		 *
 		 * @param superModel
-		 * @returns {Backbone.RelationalModel.constructor}
+		 * @returns {Backbone.Relational.Model.constructor}
 		 */
 		setup: function( superModel ) {
 			// We don't want to share a relations array with a parent, as this will cause problems with reverse
@@ -1676,7 +1680,7 @@
 
 			// If this model has 'subModelTypes' itself, remember them in the store
 			if ( this.prototype.hasOwnProperty( 'subModelTypes' ) ) {
-				Backbone.Relational.store.addSubModels( this.prototype.subModelTypes, this );
+				module.store.addSubModels( this.prototype.subModelTypes, this );
 			}
 			// The 'subModelTypes' property should not be inherited, so reset it.
 			else {
@@ -1701,15 +1705,15 @@
 						 * However, for 3. (which is, to us, indistinguishable from 2.), we do need to attempt
 						 * setting up this relation again later, in case the related model is defined later.
 						 */
-						var relatedModel = Backbone.Relational.store.getObjectByName( rel.relatedModel );
-						preInitialize = relatedModel && ( relatedModel.prototype instanceof Backbone.RelationalModel );
+						var relatedModel = module.store.getObjectByName( rel.relatedModel );
+						preInitialize = relatedModel && ( relatedModel.prototype instanceof module.Model );
 					}
 
 					if ( preInitialize ) {
-						Backbone.Relational.store.initializeRelation( null, rel );
+						module.store.initializeRelation( null, rel );
 					}
 					else if ( _.isString( rel.relatedModel ) ) {
-						Backbone.Relational.store.addOrphanRelation( rel );
+						module.store.addOrphanRelation( rel );
 					}
 				}
 			}, this );
@@ -1759,7 +1763,6 @@
 					}
 				}
 			}
-
 			return null;
 		},
 
@@ -1776,7 +1779,7 @@
 				var resolvedSubModels = _.keys( this._subModels );
 				var unresolvedSubModels = _.omit( this.prototype.subModelTypes, resolvedSubModels );
 				_.each( unresolvedSubModels, function( subModelTypeName ) {
-					var subModelType = Backbone.Relational.store.getObjectByName( subModelTypeName );
+					var subModelType = module.store.getObjectByName( subModelTypeName );
 					subModelType && subModelType.initializeModelHierarchy();
 				});
 			}
@@ -1788,7 +1791,7 @@
 				return;
 			}
 			// Try to initialize the _superModel.
-			Backbone.Relational.store.setupSuperModel( this );
+			module.store.setupSuperModel( this );
 
 			// If a superModel has been found, copy relations from the _superModel if they haven't been inherited automatically
 			// (due to a redefinition of 'relations').
@@ -1816,7 +1819,7 @@
 		},
 
 		/**
-		 * Find an instance of `this` type in 'Backbone.Relational.store'.
+		 * Find an instance of `this` type in 'Backbone.store'.
 		 * A new model is created if no matching model is found, `attributes` is an object, and `options.create` is true.
 		 * - If `attributes` is a string or a number, `findOrCreate` will query the `store` and return a model if found.
 		 * - If `attributes` is an object and is found in the store, the model will be updated with `attributes` unless `options.merge` is `false`.
@@ -1825,7 +1828,7 @@
 		 * @param {Boolean} [options.create=true]
 		 * @param {Boolean} [options.merge=true]
 		 * @param {Boolean} [options.parse=false]
-		 * @return {Backbone.RelationalModel}
+		 * @return {Backbone.Relational.Model}
 		 */
 		findOrCreate: function( attributes, options ) {
 			options || ( options = {} );
@@ -1855,14 +1858,14 @@
 		},
 
 		/**
-		 * Find an instance of `this` type in 'Backbone.Relational.store'.
+		 * Find an instance of `this` type in 'Backbone.store'.
 		 * - If `attributes` is a string or a number, `find` will query the `store` and return a model if found.
 		 * - If `attributes` is an object and is found in the store, the model will be updated with `attributes` unless `options.merge` is `false`.
 		 * @param {Object|String|Number} attributes Either a model's id, or the attributes used to create or update a model.
 		 * @param {Object} [options]
 		 * @param {Boolean} [options.merge=true]
 		 * @param {Boolean} [options.parse=false]
-		 * @return {Backbone.RelationalModel}
+		 * @return {Backbone.Relational.Model}
 		 */
 		find: function( attributes, options ) {
 			options || ( options = {} );
@@ -1874,22 +1877,22 @@
 		 * A hook to override the matching when updating (or creating) a model.
 		 * The default implementation is to look up the model by id in the store.
 		 * @param {Object} attributes
-		 * @returns {Backbone.RelationalModel}
+		 * @returns {Backbone.Relational.Model}
 		 */
 		findModel: function( attributes ) {
-			return Backbone.Relational.store.find( this, attributes );
+			return module.store.find( this, attributes );
 		}
 	});
-	_.extend( Backbone.RelationalModel.prototype, Backbone.Semaphore );
+	_.extend( module.Model.prototype, module.Semaphore );
 
 	/**
-	 * Override Backbone.Collection._prepareModel, so objects will be built using the correct type
+	 * Override module.Collection._prepareModel, so objects will be built using the correct type
 	 * if the collection.model has subModels.
 	 * Attempts to find a model for `attrs` in Backbone.store through `findOrCreate`
 	 * (which sets the new properties on it if found), or instantiates a new model.
 	 */
-	Backbone.Collection.prototype.__prepareModel = Backbone.Collection.prototype._prepareModel;
-	Backbone.Collection.prototype._prepareModel = function( attrs, options ) {
+	module.Collection.prototype.__prepareModel = module.Collection.prototype._prepareModel;
+	module.Collection.prototype._prepareModel = function( attrs, options ) {
 		var model;
 
 		if ( attrs instanceof Backbone.Model ) {
@@ -1920,13 +1923,13 @@
 
 
 	/**
-	 * Override Backbone.Collection.set, so we'll create objects from attributes where required,
+	 * Override module.Collection.set, so we'll create objects from attributes where required,
 	 * and update the existing models. Also, trigger 'relational:add'.
 	 */
-	var set = Backbone.Collection.prototype.__set = Backbone.Collection.prototype.set;
-	Backbone.Collection.prototype.set = function( models, options ) {
+	var set = module.Collection.prototype.__set = module.Collection.prototype.set;
+	module.Collection.prototype.set = function( models, options ) {
 		// Short-circuit if this Collection doesn't hold RelationalModels
-		if ( !( this.model.prototype instanceof Backbone.RelationalModel ) ) {
+		if ( !( this.model.prototype instanceof module.Model ) ) {
 			return set.call( this, models, options );
 		}
 
@@ -1945,16 +1948,18 @@
 		for ( var i = 0; i < models.length; i++ ) {
 			model = models[i];
 			if ( !( model instanceof Backbone.Model ) ) {
-				model = Backbone.Collection.prototype._prepareModel.call( this, model, options );
+				model = module.Collection.prototype._prepareModel.call( this, model, options );
 			}
+
 			if ( model ) {
 				toAdd.push( model );
+
 				if ( !( this.get( model ) || this.get( model.cid ) ) ) {
 					newModels.push( model );
 				}
 				// If we arrive in `add` while performing a `set` (after a create, so the model gains an `id`),
 				// we may get here before `_onModelEvent` has had the chance to update `_byId`.
-				else if ( model.id !== null && model.id !== undefined ) {
+				else if ( model.id != null ) {
 					this._byId[ model.id ] = model;
 				}
 			}
@@ -1982,7 +1987,7 @@
 	var _removeModels = Backbone.Collection.prototype.___removeModels = Backbone.Collection.prototype._removeModels;
 	Backbone.Collection.prototype._removeModels = function( models, options ) {
 		// Short-circuit if this Collection doesn't hold RelationalModels
-		if ( !( this.model.prototype instanceof Backbone.RelationalModel ) ) {
+		if ( !( this.model.prototype instanceof module.Model ) ) {
 			return _removeModels.call( this, models, options );
 		}
 
@@ -2004,14 +2009,14 @@
 	};
 
 	/**
-	 * Override 'Backbone.Collection.reset' to trigger 'relational:reset'.
+	 * Override 'module.Collection.reset' to trigger 'relational:reset'.
 	 */
-	var reset = Backbone.Collection.prototype.__reset = Backbone.Collection.prototype.reset;
-	Backbone.Collection.prototype.reset = function( models, options ) {
+	var reset = module.Collection.prototype.__reset = module.Collection.prototype.reset;
+	module.Collection.prototype.reset = function( models, options ) {
 		options = _.extend( { merge: true }, options );
 		var result = reset.call( this, models, options );
 
-		if ( this.model.prototype instanceof Backbone.RelationalModel ) {
+		if ( this.model.prototype instanceof module.Model ) {
 			this.trigger( 'relational:reset', this, options );
 		}
 
@@ -2019,13 +2024,13 @@
 	};
 
 	/**
-	 * Override 'Backbone.Collection.sort' to trigger 'relational:reset'.
+	 * Override 'module.Collection.sort' to trigger 'relational:reset'.
 	 */
-	var sort = Backbone.Collection.prototype.__sort = Backbone.Collection.prototype.sort;
-	Backbone.Collection.prototype.sort = function( options ) {
+	var sort = module.Collection.prototype.__sort = module.Collection.prototype.sort;
+	module.Collection.prototype.sort = function( options ) {
 		var result = sort.call( this, options );
 
-		if ( this.model.prototype instanceof Backbone.RelationalModel ) {
+		if ( this.model.prototype instanceof module.Model ) {
 			this.trigger( 'relational:reset', this, options );
 		}
 
@@ -2033,13 +2038,13 @@
 	};
 
 	/**
-	 * Override 'Backbone.Collection.trigger' so 'add', 'remove' and 'reset' events are queued until relations
+	 * Override 'module.Collection.trigger' so 'add', 'remove' and 'reset' events are queued until relations
 	 * are ready.
 	 */
-	var trigger = Backbone.Collection.prototype.__trigger = Backbone.Collection.prototype.trigger;
-	Backbone.Collection.prototype.trigger = function( eventName ) {
+	var trigger = module.Collection.prototype.__trigger = module.Collection.prototype.trigger;
+	module.Collection.prototype.trigger = function( eventName ) {
 		// Short-circuit if this Collection doesn't hold RelationalModels
-		if ( !( this.model.prototype instanceof Backbone.RelationalModel ) ) {
+		if ( !( this.model.prototype instanceof module.Model ) ) {
 			return trigger.apply( this, arguments );
 		}
 
@@ -2054,7 +2059,7 @@
 				args[ 3 ] = _.clone( args[ 3 ] );
 			}
 
-			Backbone.Relational.eventQueue.add( function() {
+			module.eventQueue.add( function() {
 				trigger.apply( dit, args );
 			});
 		}
@@ -2066,11 +2071,12 @@
 	};
 
 	// Override .extend() to automatically call .setup()
-	Backbone.RelationalModel.extend = function( protoProps, classProps ) {
-		var child = Backbone.Model.extend.call( this, protoProps, classProps );
+	module.Model.extend = function( protoProps, classProps ) {
+		var child = Backbone.Model.extend.apply( this, arguments );
 
 		child.setup( this );
 
 		return child;
 	};
+	return module;
 }));

--- a/test/backbone.js
+++ b/test/backbone.js
@@ -6,39 +6,39 @@ QUnit.module( "General / Backbone", { setup: require('./setup/setup').reset } );
 			i = new Backbone.Model(),
 			iModel = new Model();
 
-		var RelModel= Backbone.RelationalModel.extend(),
-			iRel = new Backbone.RelationalModel(),
+		var RelModel= Backbone.Relational.Model.extend(),
+			iRel = new Backbone.Relational.Model(),
 			iRelModel = new RelModel();
 
 		// Both are functions, so their `constructor` is `Function`
-		ok( Backbone.Model.constructor === Backbone.RelationalModel.constructor );
+		ok( Backbone.Model.constructor === Backbone.Relational.Model.constructor );
 
-		ok( Backbone.Model !== Backbone.RelationalModel );
+		ok( Backbone.Model !== Backbone.Relational.Model );
 		ok( Backbone.Model === Backbone.Model.prototype.constructor );
-		ok( Backbone.RelationalModel === Backbone.RelationalModel.prototype.constructor );
-		ok( Backbone.Model.prototype.constructor !== Backbone.RelationalModel.prototype.constructor );
+		ok( Backbone.Relational.Model === Backbone.Relational.Model.prototype.constructor );
+		ok( Backbone.Model.prototype.constructor !== Backbone.Relational.Model.prototype.constructor );
 
 		ok( Model.prototype instanceof Backbone.Model );
-		ok( !( Model.prototype instanceof Backbone.RelationalModel ) );
+		ok( !( Model.prototype instanceof Backbone.Relational.Model ) );
 		ok( RelModel.prototype instanceof Backbone.Model );
-		ok( Backbone.RelationalModel.prototype instanceof Backbone.Model );
-		ok( RelModel.prototype instanceof Backbone.RelationalModel );
+		ok( Backbone.Relational.Model.prototype instanceof Backbone.Model );
+		ok( RelModel.prototype instanceof Backbone.Relational.Model );
 
 		ok( i instanceof Backbone.Model );
-		ok( !( i instanceof Backbone.RelationalModel ) );
+		ok( !( i instanceof Backbone.Relational.Model ) );
 		ok( iRel instanceof Backbone.Model );
-		ok( iRel instanceof Backbone.RelationalModel );
+		ok( iRel instanceof Backbone.Relational.Model );
 
 		ok( iModel instanceof Backbone.Model );
-		ok( !( iModel instanceof Backbone.RelationalModel ) );
+		ok( !( iModel instanceof Backbone.Relational.Model ) );
 		ok( iRelModel instanceof Backbone.Model );
-		ok( iRelModel instanceof Backbone.RelationalModel );
+		ok( iRelModel instanceof Backbone.Relational.Model );
 	});
 
 	QUnit.test('Collection#set', 1, function() {
 		var a = new Backbone.Model({id: 3, label: 'a'} ),
 			b = new Backbone.Model({id: 2, label: 'b'} ),
-			col = new Backbone.Collection([a]);
+			col = new Backbone.Relational.Collection([a]);
 
 		col.set([a,b], {add: true, merge: false, remove: true});
 		ok( col.length === 2 );

--- a/test/benchmarks.js
+++ b/test/benchmarks.js
@@ -3,48 +3,47 @@ QUnit.module( "Performance", { setup: require('./setup/setup').reset } );
 	QUnit.test( "Creation and destruction", 0, function() {
 		var registerCount = 0,
 			unregisterCount = 0,
-			register = Backbone.Store.prototype.register,
-			unregister = Backbone.Store.prototype.unregister;
+			register = Backbone.Relational.Store.prototype.register,
+			unregister = Backbone.Relational.Store.prototype.unregister;
 
-		Backbone.Store.prototype.register = function( model ) {
+		Backbone.Relational.Store.prototype.register = function( model ) {
 			registerCount++;
 			return register.apply( this, arguments );
 		};
-		Backbone.Store.prototype.unregister = function( model, coll, options ) {
+		Backbone.Relational.Store.prototype.unregister = function( model, coll, options ) {
 			unregisterCount++;
 			return unregister.apply( this, arguments );
 		};
 
 		var addHasManyCount = 0,
 			addHasOneCount = 0,
-			tryAddRelatedHasMany = Backbone.HasMany.prototype.tryAddRelated,
-			tryAddRelatedHasOne = Backbone.HasOne.prototype.tryAddRelated;
+			tryAddRelatedHasMany = Backbone.Relational.HasMany.prototype.tryAddRelated,
+			tryAddRelatedHasOne = Backbone.Relational.HasOne.prototype.tryAddRelated;
 
-		Backbone.Store.prototype.tryAddRelated = function( model, coll, options ) {
+		Backbone.Relational.Store.prototype.tryAddRelated = function( model, coll, options ) {
 			addHasManyCount++;
 			return tryAddRelatedHasMany.apply( this, arguments );
 		};
-		Backbone.HasOne.prototype.tryAddRelated = function( model, coll, options ) {
+		Backbone.Relational.HasOne.prototype.tryAddRelated = function( model, coll, options ) {
 			addHasOneCount++;
 			return tryAddRelatedHasOne.apply( this, arguments );
 		};
 
 		var removeHasManyCount = 0,
 			removeHasOneCount = 0,
-			removeRelatedHasMany = Backbone.HasMany.prototype.removeRelated,
-			removeRelatedHasOne= Backbone.HasOne.prototype.removeRelated;
+			removeRelatedHasMany = Backbone.Relational.HasMany.prototype.removeRelated,
+			removeRelatedHasOne= Backbone.Relational.HasOne.prototype.removeRelated;
 
-		Backbone.HasMany.prototype.removeRelated = function( model, coll, options ) {
+		Backbone.Relational.HasMany.prototype.removeRelated = function( model, coll, options ) {
 			removeHasManyCount++;
 			return removeRelatedHasMany.apply( this, arguments );
 		};
-		Backbone.HasOne.prototype.removeRelated = function( model, coll, options ) {
+		Backbone.Relational.HasOne.prototype.removeRelated = function( model, coll, options ) {
 			removeHasOneCount++;
 			return removeRelatedHasOne.apply( this, arguments );
 		};
 
-
-		var Child = Backbone.RelationalModel.extend({
+		var Child = Backbone.Relational.Model.extend({
 			url: '/child/',
 
 			toString: function() {
@@ -52,9 +51,9 @@ QUnit.module( "Performance", { setup: require('./setup/setup').reset } );
 			}
 		});
 
-		var Parent = Backbone.RelationalModel.extend({
+		var Parent = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'children',
 				relatedModel: Child,
 				reverseRelation: {
@@ -67,7 +66,7 @@ QUnit.module( "Performance", { setup: require('./setup/setup').reset } );
 			}
 		});
 
-		var Parents = Backbone.Collection.extend({
+		var Parents = Backbone.Relational.Collection.extend({
 			model: Parent
 		});
 

--- a/test/blocking-queue.js
+++ b/test/blocking-queue.js
@@ -1,7 +1,7 @@
-QUnit.module( "Backbone.BlockingQueue", { setup: require('./setup/setup').reset } );
+QUnit.module( "Backbone.Relational.BlockingQueue", { setup: require('./setup/setup').reset } );
 
 	QUnit.test( "Block", function() {
-		var queue = new Backbone.BlockingQueue();
+		var queue = new Backbone.Relational.BlockingQueue();
 		var count = 0;
 		var increment = function() { count++; };
 		var decrement = function() { count--; };

--- a/test/collection.js
+++ b/test/collection.js
@@ -1,9 +1,9 @@
-QUnit.module( "Backbone.Collection", { setup: require('./setup/setup').reset } );
+QUnit.module( "Backbone.Relational.Collection", { setup: require('./setup/setup').reset } );
 
 	QUnit.test( "Loading (fetching) multiple times updates the model, and relations's `keyContents`", function() {
-		var collA = new Backbone.Collection();
+		var collA = new Backbone.Relational.Collection();
 		collA.model = User;
-		var collB = new Backbone.Collection();
+		var collB = new Backbone.Relational.Collection();
 		collB.model = User;
 
 		// Similar to what happens when calling 'fetch' on collA, updating it, calling 'fetch' on collB
@@ -48,7 +48,7 @@ QUnit.module( "Backbone.Collection", { setup: require('./setup/setup').reset } )
 	});
 
 	QUnit.test( "Loading (fetching) a collection multiple times updates related models as well (HasMany)", function() {
-		var coll = new Backbone.Collection();
+		var coll = new Backbone.Relational.Collection();
 		coll.model = Zoo;
 
 		// Create a 'zoo' with 1 animal in it
@@ -82,8 +82,8 @@ QUnit.module( "Backbone.Collection", { setup: require('./setup/setup').reset } )
 	});
 
 	QUnit.test( "Return values for add/remove/reset/set match plain Backbone's", function() {
-		var Car = Backbone.RelationalModel.extend(),
-			Cars = Backbone.Collection.extend( { model: Car } ),
+		var Car = Backbone.Relational.Model.extend(),
+			Cars = Backbone.Relational.Collection.extend( { model: Car } ),
 			cars = new Cars();
 
 		ok( cars.add( { name: 'A' } ) instanceof Car, "Add one model" );
@@ -288,11 +288,11 @@ QUnit.module( "Backbone.Collection", { setup: require('./setup/setup').reset } )
 	});
 
 	QUnit.test( "Adding a new model doesn't `merge` it onto itself", function() {
-		var TreeModel = Backbone.RelationalModel.extend({
+		var TreeModel = Backbone.Relational.Model.extend({
 			relations: [
 				{
 					key: 'parent',
-					type: Backbone.HasOne
+					type: Backbone.Relational.HasOne
 				}
 			],
 
@@ -303,7 +303,7 @@ QUnit.module( "Backbone.Collection", { setup: require('./setup/setup').reset } )
 			}
 		});
 
-		var TreeCollection = Backbone.Collection.extend({
+		var TreeCollection = Backbone.Relational.Collection.extend({
 			model: TreeModel
 		});
 

--- a/test/has-many.js
+++ b/test/has-many.js
@@ -1,4 +1,4 @@
-QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
+QUnit.module( "Backbone.Relational.HasMany", { setup: require('./setup/data') } );
 
 	QUnit.test( "Listeners on 'add'/'remove'", 7, function() {
 		ourHouse
@@ -113,7 +113,7 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 		ok( ourHouse.get( 'occupants' ).length === 1 );
 
 		// Setting a new collection loses the original collection
-		ourHouse.set( { 'occupants': new Backbone.Collection() } );
+		ourHouse.set( { 'occupants': new Backbone.Relational.Collection() } );
 		ok( ourHouse.get( 'occupants' ).id === undefined );
 	});
 
@@ -159,7 +159,7 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 		ok( visitors.first() === visitor2 );
 
 		// Handle a Collection
-		var visitorColl = new Backbone.Collection( [ visitor1, visitor2 ] );
+		var visitorColl = new Backbone.Relational.Collection( [ visitor1, visitor2 ] );
 		zoo = new Zoo( { visitors: visitorColl } );
 		visitors = zoo.get( 'visitors' );
 
@@ -168,7 +168,7 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 		zoo.set( 'visitors', false );
 		equal( visitors.length, 0 );
 
-		visitorColl = new Backbone.Collection( [ visitor2 ] );
+		visitorColl = new Backbone.Relational.Collection( [ visitor2 ] );
 		zoo.set( 'visitors', visitorColl );
 		ok( visitorColl === zoo.get( 'visitors' ) );
 		equal( zoo.get( 'visitors' ).length, 1 );
@@ -283,9 +283,9 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 
 	QUnit.test( "Models found in 'findRelated' are all added in one go (so 'sort' will only be called once)", function() {
 		var count = 0,
-			sort = Backbone.Collection.prototype.sort;
+			sort = Backbone.Relational.Collection.prototype.sort;
 
-		Backbone.Collection.prototype.sort = function() {
+		Backbone.Relational.Collection.prototype.sort = function() {
 			count++;
 		};
 
@@ -300,7 +300,7 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 
 		equal( count, 1, "Sort is called only once" );
 
-		Backbone.Collection.prototype.sort = sort;
+		Backbone.Relational.Collection.prototype.sort = sort;
 		delete AnimalCollection.prototype.comparator;
 	});
 
@@ -372,10 +372,10 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 		equal( zoo.get( 'animals' ).zoo, undefined );
 
 
-		var FarmAnimal = Backbone.RelationalModel.extend();
-		var Barn = Backbone.RelationalModel.extend({
+		var FarmAnimal = Backbone.Relational.Model.extend();
+		var Barn = Backbone.Relational.Model.extend({
 			relations: [{
-					type: Backbone.HasMany,
+					type: Backbone.Relational.HasMany,
 					key: 'animals',
 					relatedModel: FarmAnimal,
 					collectionKey: 'barn',
@@ -392,10 +392,10 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 		equal( barn.get( 'animals' ).livesIn, undefined );
 		equal( barn.get( 'animals' ).barn, barn );
 
-		FarmAnimal = Backbone.RelationalModel.extend();
-		var BarnNoKey = Backbone.RelationalModel.extend({
+		FarmAnimal = Backbone.Relational.Model.extend();
+		var BarnNoKey = Backbone.Relational.Model.extend({
 			relations: [{
-					type: Backbone.HasMany,
+					type: Backbone.Relational.HasMany,
 					key: 'animals',
 					relatedModel: FarmAnimal,
 					collectionKey: false,
@@ -414,9 +414,9 @@ QUnit.module( "Backbone.HasMany", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "Polymorhpic relations", function() {
-		var Location = Backbone.RelationalModel.extend();
+		var Location = Backbone.Relational.Model.extend();
 
-		var Locatable = Backbone.RelationalModel.extend({
+		var Locatable = Backbone.Relational.Model.extend({
 			relations: [
 				{
 					key: 'locations',

--- a/test/has-one.js
+++ b/test/has-one.js
@@ -1,4 +1,4 @@
-QUnit.module( "Backbone.HasOne", { setup: require('./setup/data') } );
+QUnit.module( "Backbone.Relational.HasOne", { setup: require('./setup/data') } );
 
 	QUnit.test( "HasOne relations on Person are set up properly", function() {
 		ok( person1.get('likesALot') === person2 );

--- a/test/relation.js
+++ b/test/relation.js
@@ -1,4 +1,4 @@
-QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
+QUnit.module( "Backbone.Relational.Relation options", { setup: require('./setup/data') } );
 
 	QUnit.test( "`includeInJSON` (Person to JSON)", function() {
 		var json = person1.toJSON();
@@ -48,10 +48,10 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "'createModels' is false", function() {
-		var NewUser = Backbone.RelationalModel.extend({});
-		var NewPerson = Backbone.RelationalModel.extend({
+		var NewUser = Backbone.Relational.Model.extend({});
+		var NewPerson = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'user',
 				relatedModel: NewUser,
 				createModels: false
@@ -74,14 +74,14 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "Relations load from both `keySource` and `key`", function() {
-		var Property = Backbone.RelationalModel.extend({
+		var Property = Backbone.Relational.Model.extend({
 			idAttribute: 'property_id'
 		});
-		var View = Backbone.RelationalModel.extend({
+		var View = Backbone.Relational.Model.extend({
 			idAttribute: 'id',
 
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'properties',
 				keySource: 'property_ids',
 				relatedModel: Property,
@@ -122,11 +122,11 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "`keySource` is emptied after a set, doesn't get confused by `unset`", function() {
-		var SubModel = Backbone.RelationalModel.extend();
+		var SubModel = Backbone.Relational.Model.extend();
 
-		var Model = Backbone.RelationalModel.extend({
+		var Model = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'submodel',
 				keySource: 'sub_data',
 				relatedModel: SubModel
@@ -168,14 +168,14 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "'keyDestination' saves to 'key'", function() {
-		var Property = Backbone.RelationalModel.extend({
+		var Property = Backbone.Relational.Model.extend({
 			idAttribute: 'property_id'
 		});
-		var View = Backbone.RelationalModel.extend({
+		var View = Backbone.Relational.Model.extend({
 			idAttribute: 'id',
 
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'properties',
 				keyDestination: 'properties_attributes',
 				relatedModel: Property,
@@ -219,9 +219,9 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 		var collParseCalled = 0,
 			modelParseCalled = 0;
 
-		var Job = Backbone.RelationalModel.extend({});
+		var Job = Backbone.Relational.Model.extend({});
 
-		var JobCollection = Backbone.Collection.extend({
+		var JobCollection = Backbone.Relational.Collection.extend({
 			model: Job,
 
 			parse: function( resp, options ) {
@@ -230,7 +230,7 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 			}
 		});
 
-		var Company = Backbone.RelationalModel.extend({
+		var Company = Backbone.Relational.Model.extend({
 			relations: [{
 				type: 'HasMany',
 				key: 'employees',
@@ -243,7 +243,7 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 			}]
 		});
 
-		var Person = Backbone.RelationalModel.extend({
+		var Person = Backbone.Relational.Model.extend({
 			relations: [{
 				type: 'HasMany',
 				key: 'jobs',
@@ -315,12 +315,12 @@ QUnit.module( "Backbone.Relation options", { setup: require('./setup/data') } );
 		ok( collParseCalled === 0, 'coll.parse called 0 times? ' + collParseCalled );
 	});
 
-QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup').reset } );
+QUnit.module( "Backbone.Relational.Relation preconditions", { setup: require('./setup/setup').reset } );
 
 
 	QUnit.test( "'type', 'key', 'relatedModel' are required properties", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
 					key: 'listProperties',
@@ -333,10 +333,10 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 		ok( _.size( view._relations ) === 0 );
 		ok( view.getRelations().length === 0 );
 
-		View = Backbone.RelationalModel.extend({
+		View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					relatedModel: Properties
 				}
 			]
@@ -345,10 +345,10 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 		view = new View();
 		ok( _.size( view._relations ) === 0 );
 
-		View = Backbone.RelationalModel.extend({
+		View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'parentView'
 				}
 			]
@@ -360,11 +360,11 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "'type' can be a string or an object reference", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: 'Backbone.HasOne',
+					type: 'Backbone.Relational.HasOne',
 					key: 'listProperties',
 					relatedModel: Properties
 				}
@@ -374,7 +374,7 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 		var view = new View();
 		ok( _.size( view._relations ) === 1 );
 
-		View = Backbone.RelationalModel.extend({
+		View = Backbone.Relational.Model.extend({
 			relations: [
 				{
 					type: 'HasOne',
@@ -387,10 +387,10 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 		view = new View();
 		ok( _.size( view._relations ) === 1 );
 
-		View = Backbone.RelationalModel.extend({
+		View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'listProperties',
 					relatedModel: Properties
 				}
@@ -402,11 +402,11 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "'key' can be a string or an object reference", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'listProperties',
 					relatedModel: Properties
 				}
@@ -416,10 +416,10 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 		var view = new View();
 		ok( _.size( view._relations ) === 1 );
 
-		View = Backbone.RelationalModel.extend({
+		View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'listProperties',
 					relatedModel: Properties
 				}
@@ -431,8 +431,8 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "HasMany with a reverseRelation HasMany is not allowed", function() {
-		var User = Backbone.RelationalModel.extend({});
-		var Password = Backbone.RelationalModel.extend({
+		var User = Backbone.Relational.Model.extend({});
+		var Password = Backbone.Relational.Model.extend({
 			relations: [{
 				type: 'HasMany',
 				key: 'users',
@@ -453,16 +453,16 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "Duplicate relations not allowed (two simple relations)", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'properties',
 					relatedModel: Properties
 				},
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'properties',
 					relatedModel: Properties
 				}
@@ -475,20 +475,20 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "Duplicate relations not allowed (one relation with a reverse relation, one without)", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'properties',
 					relatedModel: Properties,
 					reverseRelation: {
-						type: Backbone.HasOne,
+						type: Backbone.Relational.HasOne,
 						key: 'view'
 					}
 				},
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'properties',
 					relatedModel: Properties
 				}
@@ -501,24 +501,24 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "Duplicate relations not allowed (two relations with reverse relations)", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'properties',
 					relatedModel: Properties,
 					reverseRelation: {
-						type: Backbone.HasOne,
+						type: Backbone.Relational.HasOne,
 						key: 'view'
 					}
 				},
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'properties',
 					relatedModel: Properties,
 					reverseRelation: {
-						type: Backbone.HasOne,
+						type: Backbone.Relational.HasOne,
 						key: 'view'
 					}
 				}
@@ -531,24 +531,24 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 	});
 
 	QUnit.test( "Duplicate relations not allowed (different relations, reverse relations)", function() {
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'listProperties',
 					relatedModel: Properties,
 					reverseRelation: {
-						type: Backbone.HasOne,
+						type: Backbone.Relational.HasOne,
 						key: 'view'
 					}
 				},
 				{
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'windowProperties',
 					relatedModel: Properties,
 					reverseRelation: {
-						type: Backbone.HasOne,
+						type: Backbone.Relational.HasOne,
 						key: 'view'
 					}
 				}
@@ -567,7 +567,7 @@ QUnit.module( "Backbone.Relation preconditions", { setup: require('./setup/setup
 		ok( view.get( 'windowProperties' ).get( 'name' ) === 'b' );
 	});
 
-QUnit.module( "Backbone.Relation general", { setup: require('./setup/setup').reset } );
+QUnit.module( "Backbone.Relational.Relation general", { setup: require('./setup/setup').reset } );
 
 
 	QUnit.test( "Only valid models (no validation failure) should be added to a relation", function() {
@@ -739,7 +739,7 @@ QUnit.module( "Backbone.Relation general", { setup: require('./setup/setup').res
 			employee = employees.first();
 
 		ok( company.get( 'ceo' ) === ceo );
-		ok( employees instanceof Backbone.Collection );
+		ok( employees instanceof Backbone.Relational.Collection );
 		equal( employees.length, 2 );
 
 		employee.set( 'company', null, { silent: true } );
@@ -773,10 +773,10 @@ QUnit.module( "Backbone.Relation general", { setup: require('./setup/setup').res
 		throws( function() { new Company( dataCompanyA ); }, "Can only instantiate one model for a given `id` (per model type)" );
 
 		// init-ed a lead and its nested contacts are a collection
-		ok( companyA.get('employees') instanceof Backbone.Collection, "Company's employees should be a collection" );
+		ok( companyA.get('employees') instanceof Backbone.Relational.Collection, "Company's employees should be a collection" );
 		equal(companyA.get('employees').length, 2, 'with elements');
 
-		var CompanyCollection = Backbone.Collection.extend({
+		var CompanyCollection = Backbone.Relational.Collection.extend({
 			model: Company
 		});
 		var companyCollection = new CompanyCollection( [ dataCompanyA, dataCompanyB ] );
@@ -784,7 +784,7 @@ QUnit.module( "Backbone.Relation general", { setup: require('./setup/setup').res
 		// After loading a collection with models of the same type
 		// the existing company should still have correct collections
 		ok( companyCollection.get( dataCompanyA.id ) === companyA );
-		ok( companyA.get('employees') instanceof Backbone.Collection, "Company's employees should still be a collection" );
+		ok( companyA.get('employees') instanceof Backbone.Relational.Collection, "Company's employees should still be a collection" );
 		equal( companyA.get('employees').length, 2, 'with elements' );
 	});
 
@@ -819,12 +819,12 @@ QUnit.module( "Backbone.Relation general", { setup: require('./setup/setup').res
 	});
 
 	QUnit.test( "If keySource is used, don't remove a model that is present in the key attribute", function() {
-		var ForumPost = Backbone.RelationalModel.extend({
+		var ForumPost = Backbone.Relational.Model.extend({
 			// Normally would set something here, not needed for test
 		});
-		var Forum = Backbone.RelationalModel.extend({
+		var Forum = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'posts',
 				relatedModel: ForumPost,
 				reverseRelation: {
@@ -871,10 +871,10 @@ QUnit.module( "Backbone.Relation general", { setup: require('./setup/setup').res
 
 	// GH-187
 	QUnit.test( "Can pass related model in constructor", function() {
-		var A = Backbone.RelationalModel.extend();
-		var B = Backbone.RelationalModel.extend({
+		var A = Backbone.Relational.Model.extend();
+		var B = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'a',
 				keySource: 'a_id',
 				relatedModel: A

--- a/test/relational-model.js
+++ b/test/relational-model.js
@@ -1,4 +1,4 @@
-QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
+QUnit.module( "Backbone.Relational.Model", { setup: require('./setup/data') } );
 
 	QUnit.test( "Return values: set returns the Model", function() {
 		var personId = 'person-10';
@@ -34,7 +34,7 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 		equal( relations.length, 6 );
 
 		ok( _.every( relations, function( rel ) {
-				return rel instanceof Backbone.Relation;
+				return rel instanceof Backbone.Relational.Relation;
 			})
 		);
 	});
@@ -42,12 +42,12 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 	QUnit.test( "getRelation", function() {
 		var userRel = person1.getRelation( 'user' );
 
-		ok( userRel instanceof Backbone.HasOne );
+		ok( userRel instanceof Backbone.Relational.HasOne );
 		equal( userRel.key, 'user' );
 
 		var jobsRel = person1.getRelation( 'jobs' );
 
-		ok( jobsRel instanceof Backbone.HasMany );
+		ok( jobsRel instanceof Backbone.Relational.HasMany );
 		equal( jobsRel.key, 'jobs' );
 
 		ok( person1.getRelation( 'nope' ) == null );
@@ -351,7 +351,7 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 		// Save a collection with `wait: true`
 		var zoo = new Zoo( { id: 'z1' } ),
 			animal1 = new Animal( { id: 'a1', species: 'Goat', name: 'G' } ),
-			coll = new Backbone.Collection( [ { id: 'a2', species: 'Rabbit', name: 'R' }, animal1 ] );
+			coll = new Backbone.Relational.Collection( [ { id: 'a2', species: 'Rabbit', name: 'R' }, animal1 ] );
 
 		request = zoo.save( 'animals', coll, { wait: true } );
 		json = JSON.parse( request.data );
@@ -533,17 +533,17 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 		ok( parseCalled === 0, 'parse called 0 times? ' + parseCalled );
 
 		// Reset `parse` methods
-		Zoo.prototype.parse = Animal.prototype.parse = Backbone.RelationalModel.prototype.parse;
+		Zoo.prototype.parse = Animal.prototype.parse = Backbone.Relational.Model.prototype.parse;
 	});
 
 	QUnit.test( "`Collection#parse` with RelationalModel simple case", function() {
-		var Contact = Backbone.RelationalModel.extend({
+		var Contact = Backbone.Relational.Model.extend({
 			parse: function( response ) {
 				response.bar = response.foo * 2;
 				return response;
 			}
 		});
-		var Contacts = Backbone.Collection.extend({
+		var Contacts = Backbone.Relational.Collection.extend({
 			model: Contact,
 			url: '/contacts',
 			parse: function( response ) {
@@ -583,15 +583,15 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 			}
 		};
 
-		var Contact = Backbone.RelationalModel.extend();
-		var Contacts = Backbone.Collection.extend({
+		var Contact = Backbone.Relational.Model.extend();
+		var Contacts = Backbone.Relational.Collection.extend({
 			model: Contact
 		});
 
-		var Company = Backbone.RelationalModel.extend({
+		var Company = Backbone.Relational.Model.extend({
 			urlRoot: '/company/',
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'contacts',
 				relatedModel: Contact,
 				collectionType: Contacts
@@ -679,7 +679,7 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
 
-		scope.PetAnimal = Backbone.RelationalModel.extend({
+		scope.PetAnimal = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'cat': 'Cat',
 				'dog': 'Dog'
@@ -688,9 +688,9 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 		scope.Dog = scope.PetAnimal.extend();
 		scope.Cat = scope.PetAnimal.extend();
 
-		scope.PetOwner = Backbone.RelationalModel.extend({
+		scope.PetOwner = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'pets',
 				relatedModel: scope.PetAnimal,
 				reverseRelation: {
@@ -769,10 +769,10 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "Model's collection children should be in the proper order during fetch w/remove: false", function() {
-		var Child = Backbone.RelationalModel.extend();
-		var Parent = Backbone.RelationalModel.extend( {
+		var Child = Backbone.Relational.Model.extend();
+		var Parent = Backbone.Relational.Model.extend( {
 			relations: [ {
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'children',
 				relatedModel: Child
 			} ]
@@ -800,7 +800,7 @@ QUnit.module( "Backbone.RelationalModel", { setup: require('./setup/data') } );
 		deepEqual( children.pluck('id'), ['foo1', 'foo2'], 'children are in the right order' );
 	});
 
-QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup: require('./setup/setup').reset } );
+QUnit.module( "Backbone.Relational.Model inheritance (`subModelTypes`)", { setup: require('./setup/setup').reset } );
 
 	QUnit.test( "Object building based on type, when using explicit collections" , function() {
 		var scope = {};
@@ -842,7 +842,7 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
 
-		var PetAnimal = scope.PetAnimal = Backbone.RelationalModel.extend({
+		var PetAnimal = scope.PetAnimal = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'cat': 'Cat',
 				'dog': 'Dog'
@@ -856,9 +856,9 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		var Cat = scope.Cat = PetAnimal.extend();
 		var Poodle = scope.Poodle = Dog.extend();
 
-		var PetPerson = scope.PetPerson = Backbone.RelationalModel.extend({
+		var PetPerson = scope.PetPerson = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'pets',
 				relatedModel: PetAnimal,
 				reverseRelation: {
@@ -904,7 +904,7 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
 
-		var Caveman = scope.Caveman = Backbone.RelationalModel.extend({
+		var Caveman = scope.Caveman = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'rubble': 'Rubble',
 				'flintstone': 'Flintstone'
@@ -914,9 +914,9 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		var Flintstone = scope.Flintstone = Caveman.extend();
 		var Rubble = scope.Rubble = Caveman.extend();
 
-		var Cartoon = scope.Cartoon = Backbone.RelationalModel.extend({
+		var Cartoon = scope.Cartoon = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'cavemen',
 				relatedModel: Caveman
 			}]
@@ -956,24 +956,24 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
 
-		scope.PetPerson = Backbone.RelationalModel.extend({});
-		scope.PetAnimal = Backbone.RelationalModel.extend({
+		scope.PetPerson = Backbone.Relational.Model.extend({});
+		scope.PetAnimal = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'dog': 'Dog'
 			},
 
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key:  'owner',
 				relatedModel: scope.PetPerson,
 				reverseRelation: {
-					type: Backbone.HasMany,
+					type: Backbone.Relational.HasMany,
 					key: 'pets'
 				}
 			}]
 		});
 
-		scope.Flea = Backbone.RelationalModel.extend({});
+		scope.Flea = Backbone.Relational.Model.extend({});
 
 		scope.Dog = scope.PetAnimal.extend({
 			subModelTypes: {
@@ -981,7 +981,7 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 			},
 
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key:	'fleas',
 				relatedModel: scope.Flea,
 				reverseRelation: {
@@ -1021,19 +1021,19 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 	QUnit.test( "Initialization and sharing of 'superModel' reverse relations from a 'leaf' child model" , function() {
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
-		scope.PetAnimal = Backbone.RelationalModel.extend({
+		scope.PetAnimal = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'dog': 'Dog'
 			}
 		});
 
-		scope.Flea = Backbone.RelationalModel.extend({});
+		scope.Flea = Backbone.Relational.Model.extend({});
 		scope.Dog = scope.PetAnimal.extend({
 			subModelTypes: {
 				'poodle': 'Poodle'
 			},
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key:	'fleas',
 				relatedModel: scope.Flea,
 				reverseRelation: {
@@ -1044,13 +1044,13 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		scope.Poodle = scope.Dog.extend();
 
 		// Define the PetPerson after defining all of the Animal models. Include the 'owner' as a reverse-relation.
-		scope.PetPerson = Backbone.RelationalModel.extend({
+		scope.PetPerson = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key:  'pets',
 				relatedModel: scope.PetAnimal,
 				reverseRelation: {
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'owner'
 				}
 			}]
@@ -1087,7 +1087,7 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 	QUnit.test( "Initialization and sharing of 'superModel' reverse relations by adding to a polymorphic HasMany" , function() {
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
-		scope.PetAnimal = Backbone.RelationalModel.extend({
+		scope.PetAnimal = Backbone.Relational.Model.extend({
 			// The order in which these are defined matters for this regression test.
 			subModelTypes: {
 				'dog': 'Dog',
@@ -1098,13 +1098,13 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		// This looks unnecessary but it's for this regression test there has to be multiple subModelTypes.
 		scope.Fish = scope.PetAnimal.extend({});
 
-		scope.Flea = Backbone.RelationalModel.extend({});
+		scope.Flea = Backbone.Relational.Model.extend({});
 		scope.Dog = scope.PetAnimal.extend({
 			subModelTypes: {
 				'poodle': 'Poodle'
 			},
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key:	'fleas',
 				relatedModel: scope.Flea,
 				reverseRelation: {
@@ -1115,13 +1115,13 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		scope.Poodle = scope.Dog.extend({});
 
 		// Define the PetPerson after defining all of the Animal models. Include the 'owner' as a reverse-relation.
-		scope.PetPerson = Backbone.RelationalModel.extend({
+		scope.PetPerson = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key:  'pets',
 				relatedModel: scope.PetAnimal,
 				reverseRelation: {
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'owner'
 				}
 			}]
@@ -1143,16 +1143,16 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		var models = {};
 		Backbone.Relational.store.addModelScope( models );
 
-		models.URL = Backbone.RelationalModel.extend({});
+		models.URL = Backbone.Relational.Model.extend({});
 
-		models.File = Backbone.RelationalModel.extend({
+		models.File = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'video': 'Video',
 				'publication': 'Publication'
 			},
 
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'url',
 				relatedModel: models.URL
 			}]
@@ -1161,17 +1161,17 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		models.Video = models.File.extend({});
 
 		// Publication redefines the `url` relation
-		models.Publication = Backbone.RelationalModel.extend({
+		models.Publication = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'url',
 				relatedModel: models.URL
 			}]
 		});
 
-		models.Project = Backbone.RelationalModel.extend({
+		models.Project = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'files',
 				relatedModel: models.File,
 				reverseRelation: {
@@ -1234,17 +1234,17 @@ QUnit.module( "Backbone.RelationalModel inheritance (`subModelTypes`)", { setup:
 		equal( _.size( file3._relations ), 2 );
 
 		ok( file1.get( 'url' ) instanceof Backbone.Model, '`url` on Video is a model' );
-		ok( file1.getRelation( 'url' ) instanceof Backbone.HasOne, '`url` relation on Video is HasOne' );
+		ok( file1.getRelation( 'url' ) instanceof Backbone.Relational.HasOne, '`url` relation on Video is HasOne' );
 
-		ok( file3.get( 'url' ) instanceof Backbone.Collection, '`url` on Publication is a collection' );
-		ok( file3.getRelation( 'url' ) instanceof Backbone.HasMany, '`url` relation on Publication is HasMany' );
+		ok( file3.get( 'url' ) instanceof Backbone.Relational.Collection, '`url` on Publication is a collection' );
+		ok( file3.getRelation( 'url' ) instanceof Backbone.Relational.HasMany, '`url` relation on Publication is HasMany' );
 	});
 
 	QUnit.test( "toJSON includes the type", function() {
 		var scope = {};
 		Backbone.Relational.store.addModelScope( scope );
 
-		scope.PetAnimal = Backbone.RelationalModel.extend({
+		scope.PetAnimal = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'dog': 'Dog'
 			}

--- a/test/reverse-relations.js
+++ b/test/reverse-relations.js
@@ -137,11 +137,13 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 	QUnit.test( "'Save' objects (performing 'set' multiple times without and with id)", 4, function() {
 		person3
 			.on( 'add:jobs', function( model, coll ) {
+				console.log('got here 1');
 				var company = model.get('company');
 				ok( company instanceof Company && company.get('ceo').get('name') === 'Lunar boy' && model.get('person') === person3,
 					"add:jobs: Both Person and Company are set on the Job instance once the event gets fired" );
 			})
 			.on( 'remove:jobs', function( model, coll ) {
+				console.log('got here 2');
 				ok( false, "remove:jobs: 'person3' should not lose his job" );
 			});
 
@@ -156,11 +158,13 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 
 		company
 			.on( 'add:employees', function( model, coll ) {
+				console.log('got here 3');
 				var company = model.get('company');
 				ok( company instanceof Company && company.get('ceo').get('name') === 'Lunar boy' && model.get('person') === person3,
 					"add:employees: Both Person and Company are set on the Company instance once the event gets fired" );
 			})
 			.on( 'remove:employees', function( model, coll ) {
+				console.log('got here 4');
 				ok( true, "'remove:employees: person3' should lose a job once" );
 			});
 
@@ -238,15 +242,15 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 		// This test caused a race condition to surface:
 		// The 'relation's constructor initializes the 'reverseRelation', which called 'relation.addRelated' in it's 'initialize'.
 		// However, 'relation's 'initialize' has not been executed yet, so it doesn't have a 'related' collection yet.
-		var Properties = Backbone.RelationalModel.extend({});
-		var View = Backbone.RelationalModel.extend({
+		var Properties = Backbone.Relational.Model.extend({});
+		var View = Backbone.Relational.Model.extend({
 			relations: [
 				{
-					type: Backbone.HasMany,
+					type: Backbone.Relational.HasMany,
 					key: 'properties',
 					relatedModel: Properties,
 					reverseRelation: {
-						type: Backbone.HasOne,
+						type: Backbone.Relational.HasOne,
 						key: 'view'
 					}
 				}
@@ -264,14 +268,14 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "Reverse relations are found for models that have not been instantiated and use .extend()", function() {
-		var View = Backbone.RelationalModel.extend({ });
-		var Property = Backbone.RelationalModel.extend({
+		var View = Backbone.Relational.Model.extend({ });
+		var Property = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'view',
 				relatedModel: View,
 				reverseRelation: {
-					type: Backbone.HasMany,
+					type: Backbone.Relational.HasMany,
 					key: 'properties'
 				}
 			}]
@@ -282,22 +286,22 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 			properties: [ { id: 1, key: 'width', value: '300px' } ]
 		});
 
-		ok( view.get( 'properties' ) instanceof Backbone.Collection );
+		ok( view.get( 'properties' ) instanceof Backbone.Relational.Collection );
 	});
 
 	QUnit.test( "Reverse relations found for models that have not been instantiated and run .setup() manually", function() {
 		// Generated from CoffeeScript code:
-		// 	 class View extends Backbone.RelationalModel
+		// 	 class View extends Backbone.Relational.Model
 		//
 		// 	 View.setup()
 		//
-		// 	 class Property extends Backbone.RelationalModel
+		// 	 class Property extends Backbone.Relational.Model
 		// 	   relations: [
-		// 	     type: Backbone.HasOne
+		// 	     type: Backbone.Relational.HasOne
 		// 	     key: 'view'
 		// 	     relatedModel: View
 		// 	     reverseRelation:
-		// 	       type: Backbone.HasMany
+		// 	       type: Backbone.Relational.HasMany
 		// 	       key: 'properties'
 		// 	   ]
 		//
@@ -317,7 +321,7 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 			}
 
 			return View;
-		})( Backbone.RelationalModel );
+		})( Backbone.Relational.Model );
 
 		View.setup();
 
@@ -331,17 +335,17 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 			}
 
 			Property.prototype.relations = [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'view',
 				relatedModel: View,
 				reverseRelation: {
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 					key: 'properties'
 				}
 			}];
 
 			return Property;
-		})(Backbone.RelationalModel);
+		})(Backbone.Relational.Model);
 
 		Property.setup();
 
@@ -350,19 +354,19 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 			properties: [ { id: 1, key: 'width', value: '300px' } ]
 		});
 
-		ok( view.get( 'properties' ) instanceof Backbone.Collection );
+		ok( view.get( 'properties' ) instanceof Backbone.Relational.Collection );
 	});
 
 	QUnit.test( "ReverseRelations are applied retroactively", function() {
 		// Use brand new Model types, so we can be sure we don't have any reverse relations cached from previous tests
-		var NewUser = Backbone.RelationalModel.extend({});
-		var NewPerson = Backbone.RelationalModel.extend({
+		var NewUser = Backbone.Relational.Model.extend({});
+		var NewPerson = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'user',
 				relatedModel: NewUser,
 				reverseRelation: {
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'person'
 				}
 			}]
@@ -382,18 +386,18 @@ QUnit.module( "Reverse relations", { setup: require('./setup/data') } );
 		Backbone.Relational.store.addModelScope( models );
 
 		// Use brand new Model types, so we can be sure we don't have any reverse relations cached from previous tests
-		models.NewPerson = Backbone.RelationalModel.extend({
+		models.NewPerson = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'user',
 				relatedModel: 'NewUser',
 				reverseRelation: {
-					type: Backbone.HasOne,
+					type: Backbone.Relational.HasOne,
 					key: 'person'
 				}
 			}]
 		});
-		models.NewUser = Backbone.RelationalModel.extend({});
+		models.NewUser = Backbone.Relational.Model.extend({});
 
 		var user = new models.NewUser( { id: 'newuser-1', person: { id: 'newperson-1' } } );
 

--- a/test/semaphore.js
+++ b/test/semaphore.js
@@ -1,7 +1,7 @@
-QUnit.module( "Backbone.Semaphore", { setup: require('./setup/setup').reset } );
+QUnit.module( "Backbone.Relational.Semaphore ", { setup: require('./setup/setup').reset } );
 
 	QUnit.test( "Unbounded", 10, function() {
-		var semaphore = _.extend( {}, Backbone.Semaphore );
+		var semaphore = _.extend( {}, Backbone.Relational.Semaphore  );
 		ok( !semaphore.isLocked(), 'Semaphore is not locked initially' );
 		semaphore.acquire();
 		ok( semaphore.isLocked(), 'Semaphore is locked after acquire' );

--- a/test/setup/objects.js
+++ b/test/setup/objects.js
@@ -1,18 +1,18 @@
 var _ = window._ = require('underscore');
 var $ = window.$ = require('jquery');
 var Backbone = window.Backbone = require('backbone');
-require('../../backbone-relational');
+Backbone.Relational = require('../../backbone-relational');
 
 /**
  * 'Zoo'
  */
 
-exports.Zoo = window.Zoo = Backbone.RelationalModel.extend({
+exports.Zoo = window.Zoo = Backbone.Relational.Model.extend({
 	urlRoot: '/zoo/',
 
 	relations: [
 		{
-			type: Backbone.HasMany,
+			type: Backbone.Relational.HasMany,
 			key: 'animals',
 			relatedModel: 'Animal',
 			includeInJSON: [ 'id', 'species' ],
@@ -23,7 +23,7 @@ exports.Zoo = window.Zoo = Backbone.RelationalModel.extend({
 			}
 		},
 		{ // A simple HasMany without reverse relation
-			type: Backbone.HasMany,
+			type: Backbone.Relational.HasMany,
 			key: 'visitors',
 			relatedModel: 'Visitor'
 		}
@@ -35,12 +35,12 @@ exports.Zoo = window.Zoo = Backbone.RelationalModel.extend({
 });
 
 
-exports.Animal = window.Animal = Backbone.RelationalModel.extend({
+exports.Animal = window.Animal = Backbone.Relational.Model.extend({
 	urlRoot: '/animal/',
 
 	relations: [
 		{ // A simple HasOne without reverse relation
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'favoriteFood',
 			relatedModel: 'Food'
 		}
@@ -58,24 +58,24 @@ exports.Animal = window.Animal = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.AnimalCollection = window.AnimalCollection = Backbone.Collection.extend({
+exports.AnimalCollection = window.AnimalCollection = Backbone.Relational.Collection.extend({
 	model: Animal
 });
 
-exports.Food = window.Food = Backbone.RelationalModel.extend({
+exports.Food = window.Food = Backbone.Relational.Model.extend({
 	urlRoot: '/food/'
 });
 
-exports.Visitor = window.Visitor = Backbone.RelationalModel.extend();
+exports.Visitor = window.Visitor = Backbone.Relational.Model.extend();
 
 
 /**
  * House/Person/Job/Company
  */
 
-exports.House = window.House = Backbone.RelationalModel.extend({
+exports.House = window.House = Backbone.Relational.Model.extend({
 	relations: [{
-		type: Backbone.HasMany,
+		type: Backbone.Relational.HasMany,
 		key: 'occupants',
 		relatedModel: 'Person',
 		reverseRelation: {
@@ -89,7 +89,7 @@ exports.House = window.House = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.User = window.User = Backbone.RelationalModel.extend({
+exports.User = window.User = Backbone.Relational.Model.extend({
 	urlRoot: '/user/',
 
 	toString: function() {
@@ -97,26 +97,26 @@ exports.User = window.User = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.Person = window.Person = Backbone.RelationalModel.extend({
+exports.Person = window.Person = Backbone.Relational.Model.extend({
 	relations: [
 		{
 			// Create a cozy, recursive, one-to-one relationship
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'likesALot',
 			relatedModel: 'Person',
 			reverseRelation: {
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				key: 'likedALotBy'
 			}
 		},
 		{
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'user',
 			keyDestination: 'user_id',
 			relatedModel: 'User',
 			includeInJSON: Backbone.Model.prototype.idAttribute,
 			reverseRelation: {
-				type: Backbone.HasOne,
+				type: Backbone.Relational.HasOne,
 				includeInJSON: 'name',
 				key: 'person'
 			}
@@ -136,17 +136,17 @@ exports.Person = window.Person = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.PersonCollection = window.PersonCollection = Backbone.Collection.extend({
+exports.PersonCollection = window.PersonCollection = Backbone.Relational.Collection.extend({
 	model: Person
 });
 
-exports.Password = window.Password = Backbone.RelationalModel.extend({
+exports.Password = window.Password = Backbone.Relational.Model.extend({
 	relations: [{
-		type: Backbone.HasOne,
+		type: Backbone.Relational.HasOne,
 		key: 'user',
 		relatedModel: 'User',
 		reverseRelation: {
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'password'
 		}
 	}],
@@ -157,7 +157,7 @@ exports.Password = window.Password = Backbone.RelationalModel.extend({
 });
 
 // A link table between 'Person' and 'Company', to achieve many-to-many relations
-exports.Job = window.Job = Backbone.RelationalModel.extend({
+exports.Job = window.Job = Backbone.Relational.Model.extend({
 	defaults: {
 		'startDate': null,
 		'endDate': null
@@ -168,7 +168,7 @@ exports.Job = window.Job = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.Company = window.Company = Backbone.RelationalModel.extend({
+exports.Company = window.Company = Backbone.Relational.Model.extend({
 	relations: [{
 			type: 'HasMany',
 			key: 'employees',
@@ -196,12 +196,11 @@ exports.Company = window.Company = Backbone.RelationalModel.extend({
 /**
  * Node/NodeList
  */
-
-exports.Node = window.Node = Backbone.RelationalModel.extend({
+exports.Node = window.Node = Backbone.Relational.Model.extend({
 	urlRoot: '/node/',
 
 	relations: [{
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'parent',
 			reverseRelation: {
 				key: 'children'
@@ -214,7 +213,7 @@ exports.Node = window.Node = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.NodeList = window.NodeList = Backbone.Collection.extend({
+exports.NodeList = window.NodeList = Backbone.Relational.Collection.extend({
 	model: Node
 });
 
@@ -223,7 +222,7 @@ exports.NodeList = window.NodeList = Backbone.Collection.extend({
  * Customer/Address/Shop/Agent
  */
 
-exports.Customer = window.Customer = Backbone.RelationalModel.extend({
+exports.Customer = window.Customer = Backbone.Relational.Model.extend({
 	urlRoot: '/customer/',
 
 	toString: function() {
@@ -231,7 +230,7 @@ exports.Customer = window.Customer = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.CustomerCollection = window.CustomerCollection = Backbone.Collection.extend({
+exports.CustomerCollection = window.CustomerCollection = Backbone.Relational.Collection.extend({
 	model: Customer,
 
 	initialize: function( models, options ) {
@@ -240,7 +239,7 @@ exports.CustomerCollection = window.CustomerCollection = Backbone.Collection.ext
 	}
 });
 
-exports.Address = window.Address = Backbone.RelationalModel.extend({
+exports.Address = window.Address = Backbone.Relational.Model.extend({
 	urlRoot: '/address/',
 
 	toString: function() {
@@ -248,10 +247,10 @@ exports.Address = window.Address = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.Shop = window.Shop = Backbone.RelationalModel.extend({
+exports.Shop = window.Shop = Backbone.Relational.Model.extend({
 	relations: [
 		{
-			type: Backbone.HasMany,
+			type: Backbone.Relational.HasMany,
 			key: 'customers',
 			collectionType: 'CustomerCollection',
 			collectionOptions: function( instance ) {
@@ -261,7 +260,7 @@ exports.Shop = window.Shop = Backbone.RelationalModel.extend({
 			autoFetch: true
 		},
 		{
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'address',
 			relatedModel: 'Address',
 			autoFetch: {
@@ -280,18 +279,18 @@ exports.Shop = window.Shop = Backbone.RelationalModel.extend({
 	}
 });
 
-exports.Agent = window.Agent = Backbone.RelationalModel.extend({
+exports.Agent = window.Agent = Backbone.Relational.Model.extend({
 	urlRoot: '/agent/',
 
 	relations: [
 		{
-			type: Backbone.HasMany,
+			type: Backbone.Relational.HasMany,
 			key: 'customers',
 			relatedModel: 'Customer',
-			includeInJSON: Backbone.RelationalModel.prototype.idAttribute
+			includeInJSON: Backbone.Relational.Model.prototype.idAttribute
 		},
 		{
-			type: Backbone.HasOne,
+			type: Backbone.Relational.HasOne,
 			key: 'address',
 			relatedModel: 'Address',
 			autoFetch: false

--- a/test/setup/setup.js
+++ b/test/setup/setup.js
@@ -8,5 +8,5 @@ exports.reset = function reset() {
 
 	Backbone.Relational.store.reset();
 	Backbone.Relational.store.addModelScope( window );
-	Backbone.Relational.eventQueue = new Backbone.BlockingQueue();
+	Backbone.Relational.eventQueue = new Backbone.Relational.BlockingQueue();
 }

--- a/test/store.js
+++ b/test/store.js
@@ -1,4 +1,4 @@
-QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
+QUnit.module( "Backbone.Relational.Store", { setup: require('./setup/data') } );
 
 	QUnit.test( "Initialized", function() {
 		// `initObjects` instantiates models of the following types: `Person`, `Job`, `Company`, `User`, `House` and `Password`.
@@ -6,7 +6,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "getObjectByName", function() {
-		equal( Backbone.Relational.store.getObjectByName( 'Backbone.RelationalModel' ), Backbone.RelationalModel );
+		equal( Backbone.Relational.store.getObjectByName( 'Backbone.Relational.Model' ), Backbone.Relational.Model );
 	});
 
 	QUnit.test( "Add and remove from store", function() {
@@ -32,9 +32,9 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 		var models = {};
 		Backbone.Relational.store.addModelScope( models );
 
-		models.Book = Backbone.RelationalModel.extend({
+		models.Book = Backbone.Relational.Model.extend({
 			relations: [{
-				type: Backbone.HasMany,
+				type: Backbone.Relational.HasMany,
 				key: 'pages',
 				relatedModel: 'Page',
 				createModels: false,
@@ -43,7 +43,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 				}
 			}]
 		});
-		models.Page = Backbone.RelationalModel.extend();
+		models.Page = Backbone.Relational.Model.extend();
 
 		var book = new models.Book();
 		var page = new models.Page({ book: book });
@@ -57,7 +57,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 		ns.People = {};
 		Backbone.Relational.store.addModelScope( ns );
 
-		ns.People.Person = Backbone.RelationalModel.extend({
+		ns.People.Person = Backbone.Relational.Model.extend({
 			subModelTypes: {
 				'Student': 'People.Student'
 			},
@@ -68,7 +68,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 			iam: function() { return "I am a student"; }
 		});
 
-		ns.People.PersonCollection = Backbone.Collection.extend({
+		ns.People.PersonCollection = Backbone.Relational.Collection.extend({
 			model: ns.People.Person
 		});
 
@@ -81,7 +81,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 		var models = {};
 		Backbone.Relational.store.addModelScope( models );
 
-		models.Page = Backbone.RelationalModel.extend();
+		models.Page = Backbone.Relational.Model.extend();
 
 		ok( Backbone.Relational.store.getObjectByName( 'Page' ) === models.Page );
 		ok( Backbone.Relational.store.getObjectByName( 'Person' ) === window.Person );
@@ -190,7 +190,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 			}]
 		});
 
-		ok( anotherHouse.get('occupants') instanceof Backbone.Collection, "Occupants is a Collection" );
+		ok( anotherHouse.get('occupants') instanceof Backbone.Relational.Collection, "Occupants is a Collection" );
 		ok( anotherHouse.get('occupants').get( personId ) instanceof Person, "Occupants contains the Person with id='" + personId + "'" );
 
 		var person = Backbone.Relational.store.find( Person, personId );
@@ -215,7 +215,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 		ok( !house, houseId + " is not found in the store anymore" );
 	});
 
-	QUnit.test( "Model.collection is the first collection a Model is added to by an end-user (not its Backbone.Store collection!)", function() {
+	QUnit.test( "Model.collection is the first collection a Model is added to by an end-user (not its Backbone.Relational.Store collection!)", function() {
 		var person = new Person( { id: 5, name: 'New guy' } );
 		var personColl = new PersonCollection();
 		personColl.add( person );
@@ -322,7 +322,7 @@ QUnit.module( "Backbone.Store", { setup: require('./setup/data') } );
 	});
 
 	QUnit.test( "findOrCreate does not modify attributes hash if parse is used, prior to creating new model", function () {
-		var model = Backbone.RelationalModel.extend({
+		var model = Backbone.Relational.Model.extend({
 			parse: function( response ) {
 				response.id = response.id + 'something';
 				return response;


### PR DESCRIPTION
I decided to go ahead and do #559 instead of waiting for it, so this closes #559 . The module is exported as follows:

- `Backbone.RelationalModel` => `Backbone.Relational.Model`
- `Backbone.Collection` (the modified version) => `Backbone.Relational.Collection`
- `Backbone.BlockingQueue` => `Backbone.Relational.BlockingQueue`
- `Backbone.Store` => `Backbone.Relational.Store`
- `Backbone.Relation` => `Backbone.Relational.Relation`
- `Backbone.HasMany` => `Backbone.Relational.HasMany`
- `Backbone.HasOne` => `Backbone.Relational.HasOne`
- `Backbone.Relational.store` => `Backbone.Relational.store` (stays the same!)
- `Backbone.Semaphore` => `Backbone.Relational.Semaphore`

Usage is as follows:

**Browser**: Just include the script.
**ES6**:

`import Relational from 'backbone-relational';
Backbone.Relational = Relational;`

**RequireJS (and Node)**:

`Backbone.Relational = require('backbone-relational');`