### PR TITLE
SubModelTypes as model constructor or string

### DIFF
--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -234,7 +234,7 @@
 		setupSuperModel: function( modelType ) {
 			_.find( this._subModels, function( subModelDef ) {
 				return _.filter( subModelDef.subModels || [], function( subModelTypeName, typeValue ) {
-					var subModelType = this.getObjectByName( subModelTypeName );
+					var subModelType = !_.isString( subModelTypeName ) ? subModelTypeName : this.getObjectByName( subModelTypeName );
 
 					if ( modelType === subModelType ) {
 						// Set 'modelType' as a child of the found superModel


### PR DESCRIPTION
Of all the options that allow you to provide a Model definition, this is one of few that for some reason only allows you to provide it as string. 

This change puts this option in line with the rest of the similar options, no longer forcing you to use model scopes. 

Notations such as: 
```
subModelTypes: {
    "fade": FadeActionModel
}
```
were unsupported before.