### PR TITLE
Lodash 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4"
+  - "8"
 before_install:
   - npm install -g npm
   - npm install -g karma-cli@1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - npm install -g karma-cli
 script:
   - npm test
+  - $(npm bin)/karma start --single-run --browsers PhantomJS --lodash
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ node_js:
   - "4"
 before_install:
   - npm install -g npm
-  - npm install -g karma-cli
+  - npm install -g karma-cli@1
 script:
   - npm test
-  - $(npm bin)/karma start --single-run --browsers PhantomJS --lodash
+  - karma start --single-run --browsers PhantomJS --lodash
 sudo: false
 cache:
   directories:

--- a/backbone-relational.js
+++ b/backbone-relational.js
@@ -72,6 +72,18 @@
 	module.showWarnings = true;
 
 	/**
+	 * Partial Underscore emulation when _ is Lodash.
+	 * Please try to write code that is compatible with both, but add
+	 * compatibility code below otherwise.
+	 */
+	if (!_.any) {  // We have Lodash, make it imitate Underscore a bit more.
+		_.any = _.some;
+		_.all = _.every;
+		_.contains = _.includes;
+		_.pluck = _.map;
+	}
+
+	/**
 	 * Semaphore mixin; can be used as both binary and counting.
 	 **/
 	module.Semaphore = {
@@ -232,8 +244,8 @@
 		 * @param {Backbone.Relational.Model} modelType
 		 */
 		setupSuperModel: function( modelType ) {
-			_.find( this._subModels, function( subModelDef ) {
-				return _.filter( subModelDef.subModels || [], function( subModelTypeName, typeValue ) {
+			_.find( this._subModels, _.bind(function( subModelDef ) {
+				return _.filter( subModelDef.subModels || [], _.bind(function( subModelTypeName, typeValue ) {
 					var subModelType = this.getObjectByName( subModelTypeName );
 
 					if ( modelType === subModelType ) {
@@ -246,8 +258,8 @@
 						modelType._subModelTypeAttribute = subModelDef.superModelType.prototype.subModelTypeAttribute;
 						return true;
 					}
-				}, this ).length;
-			}, this );
+				}, this) ).length;
+			}, this) );
 		},
 
 		/**
@@ -295,13 +307,13 @@
 		 */
 		processOrphanRelations: function() {
 			// Make sure to operate on a copy since we're removing while iterating
-			_.each( this._orphanRelations.slice( 0 ), function( rel ) {
+			_.each( this._orphanRelations.slice( 0 ), _.bind(function( rel ) {
 				var relatedModel = module.store.getObjectByName( rel.relatedModel );
 				if ( relatedModel ) {
 					this.initializeRelation( null, rel );
 					this._orphanRelations = _.without( this._orphanRelations, rel );
 				}
-			}, this );
+			}, this) );
 		},
 
 		/**
@@ -316,9 +328,9 @@
 			}
 			type.prototype.relations.push( relation );
 
-			_.each( type._subModels || [], function( subModel ) {
+			_.each( type._subModels || [], _.bind(function( subModel ) {
 				this._addRelation( subModel, relation );
-			}, this );
+			}, this) );
 		},
 
 		/**
@@ -327,13 +339,13 @@
 		 */
 		retroFitRelation: function( relation ) {
 			var coll = this.getCollection( relation.model, false );
-			coll && coll.each( function( model ) {
+			coll && coll.each( _.bind(function( model ) {
 				if ( !( model instanceof relation.model ) ) {
 					return;
 				}
 
 				var rel = new relation.type( model, relation );
-			}, this );
+			}, this) );
 		},
 
 		/**
@@ -372,7 +384,7 @@
 			var parts = name.split( '.' ),
 				type = null;
 
-			_.find( this._modelScopes, function( scope ) {
+			_.find( this._modelScopes, _.bind(function( scope ) {
 				type = _.reduce( parts || [], function( memo, val ) {
 					return memo ? memo[ val ] : undefined;
 				}, scope );
@@ -380,7 +392,7 @@
 				if ( type && type !== scope ) {
 					return true;
 				}
-			}, this );
+			}, this) );
 
 			return type;
 		},
@@ -524,10 +536,10 @@
 				models = _.clone( coll.models );
 			}
 
-			_.each( models, function( model ) {
+			_.each( models, _.bind(function( model ) {
 				this.stopListening( model );
 				_.invoke( model.getRelations(), 'stopListening' );
-			}, this );
+			}, this) );
 
 
 			// If we've unregistered an entire store collection, reset the collection (which is much faster).
@@ -536,14 +548,14 @@
 				coll.reset( [] );
 			}
 			else {
-				_.each( models, function( model ) {
+				_.each( models, _.bind(function( model ) {
 					if ( coll.get( model ) ) {
 						coll.remove( model );
 					}
 					else {
 						coll.trigger( 'relational:remove', model, coll );
 					}
-				}, this );
+				}, this) );
 			}
 		},
 
@@ -555,9 +567,9 @@
 			this.stopListening();
 
 			// Unregister each collection to remove event listeners
-			_.each( this._collections, function( coll ) {
+			_.each( this._collections, _.bind(function( coll ) {
 				this.unregister( coll );
-			}, this );
+			}, this) );
 
 			this._collections = [];
 			this._subModels = [];
@@ -708,9 +720,9 @@
 			}
 			// Check if we're not attempting to create a relationship on a `key` that's already used.
 			if ( i && _.keys( i._relations ).length ) {
-				var existing = _.find( i._relations, function( rel ) {
+				var existing = _.find( i._relations, _.bind(function( rel ) {
 					return rel.key === k;
-				}, this );
+				}, this) );
 
 				if ( existing ) {
 					warn && console.warn( 'Cannot create relation=%o on %o for model=%o: already taken by relation=%o.',
@@ -785,9 +797,9 @@
 				this.setRelated( this._prepareCollection() );
 			}
 
-			_.each( this.getReverseRelations(), function( relation ) {
+			_.each( this.getReverseRelations(), _.bind(function( relation ) {
 				relation.removeRelated( this.instance );
-			}, this );
+			}, this) );
 		}
 	});
 
@@ -803,9 +815,9 @@
 			this.setRelated( related );
 
 			// Notify new 'related' object of the new relation.
-			_.each( this.getReverseRelations(), function( relation ) {
+			_.each( this.getReverseRelations(), _.bind(function( relation ) {
 				relation.addRelated( this.instance, opts );
-			}, this );
+			}, this) );
 		},
 
 		/**
@@ -869,17 +881,17 @@
 
 			// Notify old 'related' object of the terminated relation
 			if ( oldRelated && this.related !== oldRelated ) {
-				_.each( this.getReverseRelations( oldRelated ), function( relation ) {
+				_.each( this.getReverseRelations( oldRelated ), _.bind(function( relation ) {
 					relation.removeRelated( this.instance, null, options );
-				}, this );
+				}, this) );
 			}
 
 			// Notify new 'related' object of the new relation. Note we do re-apply even if this.related is oldRelated;
 			// that can be necessary for bi-directional relations if 'this.instance' was created after 'this.related'.
 			// In that case, 'this.instance' will already know 'this.related', but the reverse might not exist yet.
-			_.each( this.getReverseRelations(), function( relation ) {
+			_.each( this.getReverseRelations(), _.bind(function( relation ) {
 				relation.addRelated( this.instance, options );
-			}, this );
+			}, this) );
 
 			// Fire the 'change:<key>' event if 'related' was updated
 			if ( !options.silent && this.related !== oldRelated ) {
@@ -1018,7 +1030,7 @@
 			else {
 				var toAdd = [];
 
-				_.each( this.keyContents, function( attributes ) {
+				_.each( this.keyContents, _.bind(function( attributes ) {
 					var model = null;
 
 					if ( attributes instanceof this.relatedModel ) {
@@ -1031,7 +1043,7 @@
 					}
 
 					model && toAdd.push( model );
-				}, this );
+				}, this) );
 
 				if ( this.related instanceof module.Collection ) {
 					related = this.related;
@@ -1063,12 +1075,12 @@
 				// Handle cases the an API/user supplies just an Object/id instead of an Array
 				this.keyContents = _.isArray( keyContents ) ? keyContents : [ keyContents ];
 
-				_.each( this.keyContents, function( item ) {
+				_.each( this.keyContents, _.bind(function( item ) {
 					var itemId = module.store.resolveIdForItem( this.relatedModel, item );
 					if ( itemId || itemId === 0 ) {
 						this.keyIds.push( itemId );
 					}
-				}, this );
+				}, this) );
 			}
 		},
 
@@ -1105,9 +1117,9 @@
 			options = options ? _.clone( options ) : {};
 			this.changed = true;
 
-			_.each( this.getReverseRelations( model ), function( relation ) {
+			_.each( this.getReverseRelations( model ), _.bind(function( relation ) {
 				relation.addRelated( this.instance, options );
-			}, this );
+			}, this) );
 
 			// Only trigger 'add' once the newly added model is initialized (so, has its relations set up)
 			var dit = this;
@@ -1125,9 +1137,9 @@
 			options = options ? _.clone( options ) : {};
 			this.changed = true;
 
-			_.each( this.getReverseRelations( model ), function( relation ) {
+			_.each( this.getReverseRelations( model ), _.bind(function( relation ) {
 				relation.removeRelated( this.instance, null, options );
-			}, this );
+			}, this) );
 
 			var dit = this;
 			!options.silent && module.eventQueue.add( function() {
@@ -1304,9 +1316,9 @@
 			this.acquire(); // Setting up relations often also involve calls to 'set', and we only want to enter this function once
 			this._relations = {};
 
-			_.each( this.relations || [], function( rel ) {
+			_.each( this.relations || [], _.bind(function( rel ) {
 				module.store.initializeRelation( this, rel, options );
-			}, this );
+			}, this) );
 
 			this._isInitialized = true;
 			this.release();
@@ -1321,7 +1333,7 @@
 		 */
 		updateRelations: function( changedAttrs, options ) {
 			if ( this._isInitialized && !this.isLocked() ) {
-				_.each( this._relations, function( rel ) {
+				_.each( this._relations, _.bind(function( rel ) {
 					if ( !changedAttrs || ( rel.keySource in changedAttrs || rel.key in changedAttrs ) ) {
 						// Fetch data in `rel.keySource` if data got set in there, or `rel.key` otherwise
 						var value = this.attributes[ rel.keySource ] || this.attributes[ rel.key ],
@@ -1338,7 +1350,7 @@
 					if ( rel.keySource !== rel.key ) {
 						delete this.attributes[ rel.keySource ];
 					}
-				}, this );
+				}, this) );
 			}
 		},
 
@@ -1424,7 +1436,7 @@
 					setUrl,
 					createModels = function() {
 						// Find (or create) a model for each one that is to be fetched
-						models = _.map( idsToFetch, function( id ) {
+						models = _.map( idsToFetch, _.bind(function( id ) {
 							var model = rel.relatedModel.findModel( id );
 
 							if ( !model ) {
@@ -1435,7 +1447,7 @@
 							}
 
 							return model;
-						}, this );
+						}, this) );
 					};
 
 				// Try if the 'collection' can provide a url to fetch a set of models in one request.
@@ -1480,7 +1492,7 @@
 						createModels();
 					}
 
-					requests = _.map( models, function( model ) {
+					requests = _.map( models, _.bind(function( model ) {
 						var opts = _.defaults(
 							{
 								error: function() {
@@ -1493,7 +1505,7 @@
 							options
 						);
 						return model.fetch( opts );
-					}, this );
+					}, this) );
 				}
 			}
 
@@ -1688,7 +1700,7 @@
 			}
 
 			// Initialize all reverseRelations that belong to this new model.
-			_.each( this.prototype.relations || [], function( rel ) {
+			_.each( this.prototype.relations || [], _.bind(function( rel ) {
 				if ( !rel.model ) {
 					rel.model = this;
 				}
@@ -1716,7 +1728,7 @@
 						module.store.addOrphanRelation( rel );
 					}
 				}
-			}, this );
+			}, this) );
 
 			return this;
 		},
@@ -1802,11 +1814,11 @@
 				this._superModel.inheritRelations();
 				if ( this._superModel.prototype.relations ) {
 					// Find relations that exist on the '_superModel', but not yet on this model.
-					var inheritedRelations = _.filter( this._superModel.prototype.relations || [], function( superRel ) {
-						return !_.any( this.prototype.relations || [], function( rel ) {
+					var inheritedRelations = _.filter( this._superModel.prototype.relations || [], _.bind(function( superRel ) {
+						return !_.any( this.prototype.relations || [], _.bind(function( rel ) {
 							return superRel.relatedModel === rel.relatedModel && superRel.key === rel.key;
-						}, this );
-					}, this );
+						}, this) );
+					}, this) );
 
 					this.prototype.relations = inheritedRelations.concat( this.prototype.relations );
 				}
@@ -1994,16 +2006,16 @@
 		var toRemove = [];
 
 		//console.debug('calling remove on coll=%o; models=%o, options=%o', this, models, options );
-		_.each( models, function( model ) {
+		_.each( models, _.bind(function( model ) {
 			model = this.get( model ) || ( model && this.get( model.cid ) );
 			model && toRemove.push( model );
-		}, this );
+		}, this) );
 
 		var result = _removeModels.call( this, toRemove, options );
 
-		_.each( toRemove, function( model ) {
+		_.each( toRemove, _.bind(function( model ) {
 			this.trigger( 'relational:remove', model, this, options );
-		}, this );
+		}, this) );
 
 		return result;
 	};

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
 
 		<p>
 			Backbone-relational depends on <a href="http://backbonejs.org/">Backbone.js</a> <small>(>= 1.2.1)</small>,
-			which itself requires <a href="http://underscorejs.org">Underscore.js</a> <small>(> 1.7.0)</small> and
+			which itself requires <a href="http://underscorejs.org">Underscore.js</a> <small>(> 1.7.0)</small> or <a href="https://lodash.com">Lodash</a> <small>(>= 3)</small> and
 			<a href="http://jquery.com">jQuery</a> <small>(> 1.7.0)</small> or
 			<a href="http://zeptojs.com/">Zepto</a>.
 		</p>
@@ -254,6 +254,10 @@
 			Note for <strong>CoffeeScript</strong> users: due to the way the <q>extends</q> keyword is implemented in
 			CoffeeScript, you may have to make an extra call to <a href="#RelationalModel-setup"><q>setup</q></a> for
 			your models. See the <a href="#RelationalModel-setup"><q>setup</q></a> documentation for details.
+		</p>
+
+		<p class="notice">
+			Note for <strong>Lodash</strong> users: you can use Lodash (version 3 or greater) instead of Underscore.
 		</p>
 	</section>
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,14 @@
 module.exports = function(config) {
+	var browserifyOptions = {
+		debug: true
+	};
+	if (config.lodash) browserifyOptions.transform = [
+		['aliasify', {
+			aliases: {
+				underscore: 'lodash',
+			},
+		}],
+	];
 	config.set({
 		frameworks: [
 			'browserify',
@@ -20,9 +30,7 @@ module.exports = function(config) {
 			'test/**/*.js': [ 'browserify' ]
 		},
 
-		browserify: {
-			debug: true
-		},
+		browserify: browserifyOptions,
 
 		autoWatch: false,
 		port: 9877,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "version": "0.10.0",
   "devDependencies": {
+    "aliasify": "^2.1.0",
     "backbone": "^1.3.3",
     "browserify": "^13.0.0",
     "jquery": "^2.2.1",
@@ -32,6 +33,7 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-qunit": "^0.1.9",
+    "lodash": "^4.17.11",
     "phantomjs-prebuilt": "^2.1.5",
     "qunitjs": "^1.22.0",
     "semver": "^5.1.0",


### PR DESCRIPTION
Resolves #561. Summary of changes:

 - It is now possible to run the entire test suite with Lodash instead of Underscore by passing the `--lodash` option to `karma start`. Still runs with Underscore by default. (Tip for Yarn users: you can just do `yarn test --lodash`).
 - Feature detection of `_.any` is used to determine whether the `_` factory argument is Underscore or Lodash. In the latter case, some aliases are created on `_` in order to keep the code changes to a minimum.
 - Everywhere a third `context` argument was passed to functions like `_.each` and `_.map`, `_.bind` is now used instead.
 - Travis build runs both the Underscore variant and the Lodash variant of the test suite (and both pass).
 - Travis config updated to use Node version 8 instead of 4, in order to resolve compatibility issues with the force-updated `npm` command line program.
 - `index.html` updated to reflect that Lodash works, too.

Note on the `CONTRIBUTING.md` and the `.editorconfig`: these files tell me that JavaScript files should be two-space indented, but the JavaScript files I edited were already tab-indented. I decided to go with the existing practice.