### PR TITLE
Prevent potential problems from a future colors@>1.4.0 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "semver": "^5.1.0",
     "underscore": ">=1.7.0",
     "watchify": "^3.7.0"
+  },
+  "overrides": {
+    "colors@>1.4.0": "1.4.0"
   }
 }


### PR DESCRIPTION
After reading https://snyk.io/blog/open-source-npm-packages-colors-faker/ and https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/, I decided to scan all JavaScript repositories on my hard drive for direct and indirect dependencies on the affected packages, using the following terminal command:

```
find . \( -name package-lock.json -or -name yarn.lock \) -exec grep -E 'colors|faker|node-ipc|js-queue|easy-stack|js-message|event-pubsub|node-cmd' '{}' ';' -print
```

(In case others want to run the same command, keep in mind that the path to the matching `package-lock.json` or `yarn.lock` comes *after* the matching lines output by `grep`.)

I found several projects that depended on `colors`, including Backbone-relational. The patch should ensure that no affected version is installed by accident, even when upgrading intermediate dependencies.